### PR TITLE
Change the way class/interface parameters are passed internally to WinRT APIs

### DIFF
--- a/packages/windows_data/lib/src/json/ijsonobject.dart
+++ b/packages/windows_data/lib/src/json/ijsonobject.dart
@@ -66,19 +66,19 @@ class IJsonObject extends IInspectable implements IJsonValue {
   void setNamedValue(String name, IJsonValue? value) {
     final nameHString = convertToHString(name);
 
-    final hr = ptr.ref.vtable
-            .elementAt(7)
-            .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(
-                            Pointer, IntPtr name, Pointer<COMObject> value)>>>()
-            .value
-            .asFunction<
-                int Function(Pointer, int name, Pointer<COMObject> value)>()(
-        ptr.ref.lpVtbl,
-        nameHString,
-        value == null ? nullptr : value.ptr.cast<Pointer<COMObject>>().value);
+    final hr =
+        ptr.ref.vtable
+                .elementAt(7)
+                .cast<
+                    Pointer<
+                        NativeFunction<
+                            HRESULT Function(
+                                Pointer, IntPtr name, LPVTBL value)>>>()
+                .value
+                .asFunction<int Function(Pointer, int name, LPVTBL value)>()(
+            ptr.ref.lpVtbl,
+            nameHString,
+            value == null ? nullptr : value.ptr.ref.lpVtbl);
 
     if (FAILED(hr)) throw WindowsException(hr);
 

--- a/packages/windows_data/lib/src/json/ijsonobjectwithdefaultvalues.dart
+++ b/packages/windows_data/lib/src/json/ijsonobjectwithdefaultvalues.dart
@@ -41,26 +41,22 @@ class IJsonObjectWithDefaultValues extends IInspectable
     final retValuePtr = calloc<COMObject>();
     final nameHString = convertToHString(name);
 
-    final hr = ptr.ref.vtable
-            .elementAt(6)
-            .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(
-                            Pointer,
-                            IntPtr name,
-                            Pointer<COMObject> defaultValue,
-                            Pointer<COMObject>)>>>()
-            .value
-            .asFunction<
-                int Function(Pointer, int name, Pointer<COMObject> defaultValue,
-                    Pointer<COMObject>)>()(
-        ptr.ref.lpVtbl,
-        nameHString,
-        defaultValue == null
-            ? nullptr
-            : defaultValue.ptr.cast<Pointer<COMObject>>().value,
-        retValuePtr);
+    final hr =
+        ptr.ref.vtable
+                .elementAt(6)
+                .cast<
+                    Pointer<
+                        NativeFunction<
+                            HRESULT Function(Pointer, IntPtr name,
+                                LPVTBL defaultValue, Pointer<COMObject>)>>>()
+                .value
+                .asFunction<
+                    int Function(Pointer, int name, LPVTBL defaultValue,
+                        Pointer<COMObject>)>()(
+            ptr.ref.lpVtbl,
+            nameHString,
+            defaultValue == null ? nullptr : defaultValue.ptr.ref.lpVtbl,
+            retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -81,26 +77,22 @@ class IJsonObjectWithDefaultValues extends IInspectable
     final retValuePtr = calloc<COMObject>();
     final nameHString = convertToHString(name);
 
-    final hr = ptr.ref.vtable
-            .elementAt(7)
-            .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(
-                            Pointer,
-                            IntPtr name,
-                            Pointer<COMObject> defaultValue,
-                            Pointer<COMObject>)>>>()
-            .value
-            .asFunction<
-                int Function(Pointer, int name, Pointer<COMObject> defaultValue,
-                    Pointer<COMObject>)>()(
-        ptr.ref.lpVtbl,
-        nameHString,
-        defaultValue == null
-            ? nullptr
-            : defaultValue.ptr.cast<Pointer<COMObject>>().value,
-        retValuePtr);
+    final hr =
+        ptr.ref.vtable
+                .elementAt(7)
+                .cast<
+                    Pointer<
+                        NativeFunction<
+                            HRESULT Function(Pointer, IntPtr name,
+                                LPVTBL defaultValue, Pointer<COMObject>)>>>()
+                .value
+                .asFunction<
+                    int Function(Pointer, int name, LPVTBL defaultValue,
+                        Pointer<COMObject>)>()(
+            ptr.ref.lpVtbl,
+            nameHString,
+            defaultValue == null ? nullptr : defaultValue.ptr.ref.lpVtbl,
+            retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -152,26 +144,22 @@ class IJsonObjectWithDefaultValues extends IInspectable
     final retValuePtr = calloc<COMObject>();
     final nameHString = convertToHString(name);
 
-    final hr = ptr.ref.vtable
-            .elementAt(9)
-            .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(
-                            Pointer,
-                            IntPtr name,
-                            Pointer<COMObject> defaultValue,
-                            Pointer<COMObject>)>>>()
-            .value
-            .asFunction<
-                int Function(Pointer, int name, Pointer<COMObject> defaultValue,
-                    Pointer<COMObject>)>()(
-        ptr.ref.lpVtbl,
-        nameHString,
-        defaultValue == null
-            ? nullptr
-            : defaultValue.ptr.cast<Pointer<COMObject>>().value,
-        retValuePtr);
+    final hr =
+        ptr.ref.vtable
+                .elementAt(9)
+                .cast<
+                    Pointer<
+                        NativeFunction<
+                            HRESULT Function(Pointer, IntPtr name,
+                                LPVTBL defaultValue, Pointer<COMObject>)>>>()
+                .value
+                .asFunction<
+                    int Function(Pointer, int name, LPVTBL defaultValue,
+                        Pointer<COMObject>)>()(
+            ptr.ref.lpVtbl,
+            nameHString,
+            defaultValue == null ? nullptr : defaultValue.ptr.ref.lpVtbl,
+            retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_devices/lib/src/enumeration/devicepicker.dart
+++ b/packages/windows_devices/lib/src/enumeration/devicepicker.dart
@@ -1,4 +1,6 @@
-// devicepicker.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: unused_import
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names

--- a/packages/windows_devices/lib/src/enumeration/idevicepicker.dart
+++ b/packages/windows_devices/lib/src/enumeration/idevicepicker.dart
@@ -1,4 +1,6 @@
-// idevicepicker.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: unused_import
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
@@ -285,23 +287,23 @@ class IDevicePicker extends IInspectable {
 
   void setDisplayStatus(Pointer<COMObject> device, String status,
       DevicePickerDisplayStatusOptions options) {
-    final statusHstring = convertToHString(status);
+    final statusHString = convertToHString(status);
 
     final hr = ptr.ref.vtable
             .elementAt(20)
             .cast<
                 Pointer<
                     NativeFunction<
-                        HRESULT Function(Pointer, Pointer<COMObject> device,
-                            IntPtr status, Uint32 options)>>>()
+                        HRESULT Function(Pointer, LPVTBL device, IntPtr status,
+                            Uint32 options)>>>()
             .value
             .asFunction<
-                int Function(Pointer, Pointer<COMObject> device, int status,
-                    int options)>()(ptr.ref.lpVtbl,
-        device.cast<Pointer<COMObject>>().value, statusHstring, options.value);
+                int Function(
+                    Pointer, LPVTBL device, int status, int options)>()(
+        ptr.ref.lpVtbl, device.ref.lpVtbl, statusHString, options.value);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
-    WindowsDeleteString(statusHstring);
+    WindowsDeleteString(statusHString);
   }
 }

--- a/packages/windows_devices/lib/src/geolocation/igeolocatorstatics2.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeolocatorstatics2.dart
@@ -56,18 +56,13 @@ class IGeolocatorStatics2 extends IInspectable {
   set defaultGeoposition(BasicGeoposition? value) {
     final hr = ptr.ref.vtable
             .elementAt(7)
-            .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(Pointer, Pointer<COMObject>)>>>()
+            .cast<Pointer<NativeFunction<HRESULT Function(Pointer, LPVTBL)>>>()
             .value
-            .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
+            .asFunction<int Function(Pointer, LPVTBL)>()(
         ptr.ref.lpVtbl,
         value == null
-            ? calloc<COMObject>()
-            : boxValue(value, convertToIReference: true)
-                .cast<Pointer<COMObject>>()
-                .value);
+            ? nullptr
+            : boxValue(value, convertToIReference: true).ref.lpVtbl);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/packages/windows_devices/lib/src/geolocation/igeolocatorwithscalaraccuracy.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeolocatorwithscalaraccuracy.dart
@@ -69,18 +69,15 @@ class IGeolocatorWithScalarAccuracy extends IInspectable
   set desiredAccuracyInMeters(int? value) {
     final hr = ptr.ref.vtable
             .elementAt(7)
-            .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(Pointer, Pointer<COMObject>)>>>()
+            .cast<Pointer<NativeFunction<HRESULT Function(Pointer, LPVTBL)>>>()
             .value
-            .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
+            .asFunction<int Function(Pointer, LPVTBL)>()(
         ptr.ref.lpVtbl,
         value == null
-            ? calloc<COMObject>()
+            ? nullptr
             : boxValue(value, convertToIReference: true, nativeType: Uint32)
-                .cast<Pointer<COMObject>>()
-                .value);
+                .ref
+                .lpVtbl);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/packages/windows_foundation/lib/src/callbacks.dart
+++ b/packages/windows_foundation/lib/src/callbacks.dart
@@ -4,8 +4,6 @@
 
 // Callbacks used in the WinRT APIs.
 
-// ignore_for_file: constant_identifier_names, non_constant_identifier_names
-
 import 'dart:ffi';
 
 import 'package:win32/win32.dart';

--- a/packages/windows_foundation/lib/src/collections/iiterable.dart
+++ b/packages/windows_foundation/lib/src/collections/iiterable.dart
@@ -1,6 +1,8 @@
-// iiterable.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: constant_identifier_names, non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:ffi';
 
@@ -24,8 +26,8 @@ class IIterable<T> extends IInspectable {
 
   /// Creates an instance of [IIterable] using the given [ptr].
   ///
-  /// [T] must be of type `int`, `String`, `Uri`, `WinRT` (e.g. `IHostName`,
-  /// `IStorageFile`) or `WinRTEnum` (e.g. `DeviceClass`).
+  /// [T] must be of type `int`, `String`, `Uri`, `WinRT` class/interface (e.g.
+  /// `HostName`, `IStorageFile`) or `WinRTEnum` (e.g. `DeviceClass`).
   ///
   /// [intType] must be specified if [T] is `int`. Supported types are: [Int16],
   /// [Int32], [Int64], [Uint8], [Uint16], [Uint32], [Uint64].
@@ -33,7 +35,7 @@ class IIterable<T> extends IInspectable {
   /// final iterable = IIterable<int>.fromRawPointer(ptr, intType: Uint64);
   /// ```
   ///
-  /// [creator] must be specified if [T] is a `WinRT` type.
+  /// [creator] must be specified if [T] is a `WinRT` class/interface.
   /// ```dart
   /// final iterable = IIterable<StorageFile>.fromRawPointer(ptr,
   ///    creator: StorageFile.fromRawPointer);

--- a/packages/windows_foundation/lib/src/collections/iiterator.dart
+++ b/packages/windows_foundation/lib/src/collections/iiterator.dart
@@ -1,6 +1,8 @@
-// iiterator.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: constant_identifier_names, non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:ffi';
 
@@ -23,8 +25,8 @@ class IIterator<T> extends IInspectable {
 
   /// Creates an instance of [IIterator] using the given [ptr].
   ///
-  /// [T] must be of type `int`, `String`, `Uri`, `WinRT` (e.g. `IHostName`,
-  /// `IStorageFile`) or `WinRTEnum` (e.g. `DeviceClass`).
+  /// [T] must be of type `int`, `String`, `Uri`, `WinRT` class/interface (e.g.
+  /// `HostName`, `IStorageFile`) or `WinRTEnum` (e.g. `DeviceClass`).
   ///
   /// [intType] must be specified if [T] is `int`. Supported types are: [Int16],
   /// [Int32], [Int64], [Uint8], [Uint16], [Uint32], [Uint64].
@@ -32,7 +34,7 @@ class IIterator<T> extends IInspectable {
   /// final iterator = IIterator<int>.fromRawPointer(ptr, intType: Uint64);
   /// ```
   ///
-  /// [creator] must be specified if [T] is a `WinRT` type.
+  /// [creator] must be specified if [T] is a `WinRT` class/interface.
   /// ```dart
   /// final iterator = IIterator<StorageFile>.fromRawPointer(ptr,
   ///    creator: StorageFile.fromRawPointer);
@@ -83,6 +85,7 @@ class IIterator<T> extends IInspectable {
     if (isSameType<T, String>()) return _current_String() as T;
     if (isSameType<T, Uri>()) return _current_Uri() as T;
     if (isSubtypeOfWinRTEnum<T>()) return _enumCreator!(_current_int());
+
     return _creator!(_current_COMObject());
   }
 

--- a/packages/windows_foundation/lib/src/collections/ikeyvaluepair.dart
+++ b/packages/windows_foundation/lib/src/collections/ikeyvaluepair.dart
@@ -1,6 +1,8 @@
-// ikeyvaluepair.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: constant_identifier_names, non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:ffi';
 
@@ -31,10 +33,10 @@ class IKeyValuePair<K, V> extends IInspectable {
   /// [K] must be of type `Guid`, `int`, `Object`, `String`, or `WinRTEnum`
   /// (e.g. `PedometerStepKind`).
   ///
-  /// [V] must be of type `Object`, `String`, or `WinRT` (e.g. `IJsonValue`,
-  /// `ProductLicense`).
+  /// [V] must be of type `Object`, `String`, or `WinRT` class/interface (e.g.
+  /// `ProductLicense`, `IJsonValue`).
   ///
-  /// [creator] must be specified if [V] is a `WinRT` type.
+  /// [creator] must be specified if [V] is a `WinRT` class/interface.
   /// ```dart
   /// final keyValuePair =
   ///     IKeyValuePair<String, IJsonValue?>.fromRawPointer(ptr,
@@ -218,6 +220,11 @@ class IKeyValuePair<K, V> extends IInspectable {
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
+    }
+
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null as V;
     }
 
     return _creator!(retValuePtr);

--- a/packages/windows_foundation/lib/src/collections/imapview.dart
+++ b/packages/windows_foundation/lib/src/collections/imapview.dart
@@ -1,6 +1,8 @@
-// imapview.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: constant_identifier_names, non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:ffi';
 
@@ -12,6 +14,7 @@ import '../iinspectable.dart';
 import '../internal/ipropertyvalue_helpers.dart';
 import '../internal/map_helpers.dart';
 import '../ipropertyvalue.dart';
+import '../types.dart';
 import '../winrt_enum.dart';
 import 'iiterable.dart';
 import 'iiterator.dart';
@@ -37,19 +40,21 @@ class IMapView<K, V> extends IInspectable
   /// [K] must be of type `Guid`, `int`, `Object`, `String`, or `WinRTEnum`
   /// (e.g. `PedometerStepKind`).
   ///
-  /// [V] must be of type `Object`, `String`, or `WinRT` (e.g. `IJsonValue`,
-  /// `ProductLicense`).
+  /// [V] must be of type `Object`, `String`, or `WinRT` class/interface (e.g.
+  /// `ProductLicense`, `IJsonValue`).
   ///
-  /// [creator] must be specified if [V] is a `WinRT` type.
+  /// [creator] must be specified if [V] is a `WinRT` class/interface.
   /// ```dart
   /// final mapView = IMapView<String, IJsonValue?>.fromRawPointer(ptr,
-  ///     creator: IJsonValue.fromRawPointer);
+  ///     creator: IJsonValue.fromRawPointer,
+  ///     iterableIid: '{dfabb6e1-0411-5a8f-aa87-354e7110f099}');
   /// ```
   ///
   /// [enumCreator] must be specified if [V] is a `WinRTEnum` type.
   /// ```dart
   /// final mapView = IMapView<String, ChatMessageStatus>.fromRawPointer(ptr,
-  ///     enumCreator: ChatMessageStatus.from);
+  ///     enumCreator: ChatMessageStatus.from,
+  ///     iterableIid: '{57d87c13-48e9-546f-9b4e-a3906e1e7c24}');
   /// ```
   IMapView.fromRawPointer(
     super.ptr, {
@@ -143,6 +148,11 @@ class IMapView<K, V> extends IInspectable
 
     free(nativeGuidPtr);
 
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null as V;
+    }
+
     return _creator!(retValuePtr);
   }
 
@@ -196,6 +206,11 @@ class IMapView<K, V> extends IInspectable
       throw WindowsException(hr);
     }
 
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null as V;
+    }
+
     return _creator!(retValuePtr);
   }
 
@@ -219,22 +234,29 @@ class IMapView<K, V> extends IInspectable
       throw WindowsException(hr);
     }
 
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null as V;
+    }
+
     return _creator!(retValuePtr);
   }
 
   Object? _lookup_Object_Object(IInspectable key) {
     final retValuePtr = calloc<COMObject>();
 
-    final hr = ptr.ref.lpVtbl.value
-            .elementAt(6)
-            .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(
-                            Pointer, COMObject, Pointer<COMObject>)>>>()
-            .value
-            .asFunction<int Function(Pointer, COMObject, Pointer<COMObject>)>()(
-        ptr.ref.lpVtbl, key.ptr.ref, retValuePtr);
+    final hr =
+        ptr.ref.lpVtbl.value
+                .elementAt(6)
+                .cast<
+                    Pointer<
+                        NativeFunction<
+                            HRESULT Function(
+                                Pointer, LPVTBL, Pointer<COMObject>)>>>()
+                .value
+                .asFunction<
+                    int Function(Pointer, LPVTBL, Pointer<COMObject>)>()(
+            ptr.ref.lpVtbl, key.ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -268,6 +290,11 @@ class IMapView<K, V> extends IInspectable
       if (FAILED(hr)) {
         free(retValuePtr);
         throw WindowsException(hr);
+      }
+
+      if (retValuePtr.ref.lpVtbl == nullptr) {
+        free(retValuePtr);
+        return null as V;
       }
 
       return _creator!(retValuePtr);
@@ -468,15 +495,14 @@ class IMapView<K, V> extends IInspectable
 
     try {
       final hr = ptr.ref.lpVtbl.value
-          .elementAt(8)
-          .cast<
-              Pointer<
-                  NativeFunction<
-                      HRESULT Function(Pointer, COMObject, Pointer<Bool>)>>>()
-          .value
-          .asFunction<
-              int Function(Pointer, COMObject,
-                  Pointer<Bool>)>()(ptr.ref.lpVtbl, value.ptr.ref, retValuePtr);
+              .elementAt(8)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          HRESULT Function(Pointer, LPVTBL, Pointer<Bool>)>>>()
+              .value
+              .asFunction<int Function(Pointer, LPVTBL, Pointer<Bool>)>()(
+          ptr.ref.lpVtbl, value.ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/packages/windows_foundation/lib/src/collections/iobservablemap.dart
+++ b/packages/windows_foundation/lib/src/collections/iobservablemap.dart
@@ -1,21 +1,16 @@
-// iobservablemap.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: unused_import
-// ignore_for_file: constant_identifier_names, non_constant_identifier_names
-// ignore_for_file: no_leading_underscores_for_local_identifiers
+// ignore_for_file: non_constant_identifier_names
 
-import 'dart:async';
 import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
 
 import '../callbacks.dart';
-import '../helpers.dart';
 import '../iinspectable.dart';
-import '../internal/hstring_array.dart';
-import 'imap.dart';
-import 'stringmap.dart';
 
 /// Notifies listeners of dynamic changes to a map, such as when items are added
 /// or removed.

--- a/packages/windows_foundation/lib/src/collections/ipropertyset.dart
+++ b/packages/windows_foundation/lib/src/collections/ipropertyset.dart
@@ -18,6 +18,7 @@ import '../../../../internal.dart';
 import '../callbacks.dart';
 import '../helpers.dart';
 import '../iinspectable.dart';
+import '../types.dart';
 import 'iiterable.dart';
 import 'iiterator.dart';
 import 'ikeyvaluepair.dart';

--- a/packages/windows_foundation/lib/src/collections/propertyset.dart
+++ b/packages/windows_foundation/lib/src/collections/propertyset.dart
@@ -18,6 +18,7 @@ import '../../../../internal.dart';
 import '../callbacks.dart';
 import '../helpers.dart';
 import '../iinspectable.dart';
+import '../types.dart';
 import 'iiterable.dart';
 import 'iiterator.dart';
 import 'ikeyvaluepair.dart';

--- a/packages/windows_foundation/lib/src/collections/stringmap.dart
+++ b/packages/windows_foundation/lib/src/collections/stringmap.dart
@@ -18,6 +18,7 @@ import '../../../../internal.dart';
 import '../callbacks.dart';
 import '../helpers.dart';
 import '../iinspectable.dart';
+import '../types.dart';
 import 'iiterable.dart';
 import 'iiterator.dart';
 import 'ikeyvaluepair.dart';

--- a/packages/windows_foundation/lib/src/collections/valueset.dart
+++ b/packages/windows_foundation/lib/src/collections/valueset.dart
@@ -18,6 +18,7 @@ import '../../../../internal.dart';
 import '../callbacks.dart';
 import '../helpers.dart';
 import '../iinspectable.dart';
+import '../types.dart';
 import 'iiterable.dart';
 import 'iiterator.dart';
 import 'ikeyvaluepair.dart';

--- a/packages/windows_foundation/lib/src/constants.dart
+++ b/packages/windows_foundation/lib/src/constants.dart
@@ -2,9 +2,9 @@
 // details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// Enums and constants used by WinRT projection
+// Constants used by WinRT projection
 
-// ignore_for_file: camel_case_types, constant_identifier_names
+// ignore_for_file: constant_identifier_names
 
 // IIterable<IKeyValuePair<K, V>> IIDs
 const IID_IIterable_IKeyValuePair_Guid_BackgroundTaskRegistration =

--- a/packages/windows_foundation/lib/src/exports.g.dart
+++ b/packages/windows_foundation/lib/src/exports.g.dart
@@ -28,5 +28,6 @@ export 'istringable.dart';
 export 'numerics/structs.g.dart';
 export 'propertyvalue.dart';
 export 'structs.g.dart';
+export 'types.dart';
 export 'winrt_com_interop_helpers.dart';
 export 'winrt_enum.dart';

--- a/packages/windows_foundation/lib/src/iasyncaction.dart
+++ b/packages/windows_foundation/lib/src/iasyncaction.dart
@@ -20,6 +20,7 @@ import 'enums.g.dart';
 import 'helpers.dart';
 import 'iasyncinfo.dart';
 import 'iinspectable.dart';
+import 'types.dart';
 
 /// @nodoc
 const IID_IAsyncAction = '{5a648006-843a-4da9-865b-9d26e5dfad7b}';

--- a/packages/windows_foundation/lib/src/iasyncinfo.dart
+++ b/packages/windows_foundation/lib/src/iasyncinfo.dart
@@ -19,6 +19,7 @@ import 'callbacks.dart';
 import 'enums.g.dart';
 import 'helpers.dart';
 import 'iinspectable.dart';
+import 'types.dart';
 
 /// @nodoc
 const IID_IAsyncInfo = '{00000036-0000-0000-c000-000000000046}';

--- a/packages/windows_foundation/lib/src/iasyncoperation.dart
+++ b/packages/windows_foundation/lib/src/iasyncoperation.dart
@@ -1,4 +1,6 @@
-// iasyncoperation.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: non_constant_identifier_names
 
@@ -29,8 +31,8 @@ class IAsyncOperation<TResult> extends IInspectable implements IAsyncInfo {
 
   /// Creates an instance of `IAsyncOperation<TResult>` using the given `ptr`.
   ///
-  /// [TResult] must be of type `bool`, `Guid`, `int`, `Object?`, `String`,
-  /// `Uri`, `WinRT` (e.g. `IBuffer`, `StorageFile`) or `WinRTEnum` (e.g.
+  /// [TResult] must be of type `bool`, `Guid`, `int`, `String`, `Uri`, `WinRT`
+  /// class/interface (e.g. `StorageFile`, `IBuffer`) or `WinRTEnum` (e.g.
   /// `LaunchUriStatus`).
   ///
   /// [intType] must be specified if [TResult] is `int`. Supported types are:
@@ -40,7 +42,7 @@ class IAsyncOperation<TResult> extends IInspectable implements IAsyncInfo {
   ///     intType: Uint64);
   /// ```
   ///
-  /// [creator] must be specified if [TResult] is a `WinRT` type.
+  /// [creator] must be specified if [TResult] is a `WinRT` class/interface.
   /// ```dart
   /// ...
   /// final asyncOperation = IAsyncOperation<StorageFile?>(ptr,

--- a/packages/windows_foundation/lib/src/iclosable.dart
+++ b/packages/windows_foundation/lib/src/iclosable.dart
@@ -18,6 +18,7 @@ import '../../../internal.dart';
 import 'callbacks.dart';
 import 'helpers.dart';
 import 'iinspectable.dart';
+import 'types.dart';
 
 /// @nodoc
 const IID_IClosable = '{30d5a829-7fa4-4026-83bb-d75bae4ea99e}';

--- a/packages/windows_foundation/lib/src/internal/comobject_pointer.dart
+++ b/packages/windows_foundation/lib/src/internal/comobject_pointer.dart
@@ -12,17 +12,17 @@ import 'package:win32/win32.dart';
 extension COMObjectPointer on Pointer<COMObject> {
   /// Creates a [List] from `Pointer<COMObject>`.
   ///
-  /// [T] must be a `WinRT` type (e.g. `IHostName`, `StorageFile`).
+  /// [T] must be a `WinRT` class/interface (e.g. `HostName`, `ICalendar`).
   ///
-  /// [creator] must be specified for [T] (e.g. `IHostName.fromRawPointer`,
-  /// `StorageFile.fromRawPointer`).
+  /// [creator] must be specified for [T] (e.g. `HostName.fromRawPointer`,
+  /// `ICalendar.fromRawPointer`).
   ///
   /// [length] must not be greater than the number of elements stored inside the
   /// `Pointer<COMObject>`.
   ///
   /// ```dart
   /// final pComObject = ...
-  /// final list = pComObject.toList(StorageFile.fromRawPointer, length: 4);
+  /// final list = pComObject.toList(HostName.fromRawPointer, length: 4);
   /// ```
   List<T> toList<T>(T Function(Pointer<COMObject>) creator, {int length = 1}) {
     final list = <T>[];

--- a/packages/windows_foundation/lib/src/internal/ipropertyvalue_helpers.dart
+++ b/packages/windows_foundation/lib/src/internal/ipropertyvalue_helpers.dart
@@ -386,11 +386,6 @@ List<int> _uint8ListFromArray(
 }
 
 IInspectable _boxValue(Object value, {Type? nativeType}) {
-  // There is no need to box IInspectable objects since .createInspectable()
-  // returns the object provided without modification.
-  // See https://docs.microsoft.com/en-us/uwp/api/windows.foundation.PropertyValue.createinspectable
-  if (value is IInspectable) return value;
-
   if (value is bool) return PropertyValue.createBoolean(value);
   if (value is DateTime) return PropertyValue.createDateTime(value);
 
@@ -480,6 +475,12 @@ Pointer<COMObject> boxValue(
   bool convertToIReference = false,
   Type? nativeType,
 }) {
+  // Since an object is a reference type, it is also a valid property value and
+  // does not need to be boxed.
+  // See https://learn.microsoft.com/en-us/uwp/api/windows.foundation.propertyvalue.createinspectable
+  if (value is Pointer<COMObject>) return value;
+  if (value is IInspectable) return value.ptr;
+
   final propertyValue = _boxValue(value, nativeType: nativeType);
   if (!convertToIReference) return propertyValue.ptr;
 

--- a/packages/windows_foundation/lib/src/internal/vector_helper.dart
+++ b/packages/windows_foundation/lib/src/internal/vector_helper.dart
@@ -2,7 +2,7 @@
 // details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: camel_case_types, non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names
 
 import 'dart:ffi';
 
@@ -80,7 +80,7 @@ class VectorHelper<T> {
   }
 
   List<T> _toList_enum() {
-    // The only valid WinRT types for enums are Int32 or UInt32.
+    // The only valid types for enums are Int32 or UInt32.
     // See https://docs.microsoft.com/en-us/uwp/winrt-cref/winrt-type-system#enums
     switch (intType) {
       case Uint32:
@@ -209,6 +209,6 @@ class VectorHelper<T> {
   }
 }
 
-// WinRT Type system does not support Int8 types.
+// WinRT type system does not support Int8 types.
 // See https://docs.microsoft.com/en-us/uwp/winrt-cref/winrt-type-system#fundamental-types
 const supportedIntTypes = [Int16, Int32, Int64, Uint8, Uint16, Uint32, Uint64];

--- a/packages/windows_foundation/lib/src/ipropertyvalue.dart
+++ b/packages/windows_foundation/lib/src/ipropertyvalue.dart
@@ -20,6 +20,7 @@ import 'enums.g.dart';
 import 'helpers.dart';
 import 'iinspectable.dart';
 import 'structs.g.dart';
+import 'types.dart';
 
 /// @nodoc
 const IID_IPropertyValue = '{4bd682dd-7554-40e9-9a9b-82654ede7e62}';

--- a/packages/windows_foundation/lib/src/ipropertyvaluestatics.dart
+++ b/packages/windows_foundation/lib/src/ipropertyvaluestatics.dart
@@ -20,6 +20,7 @@ import 'helpers.dart';
 import 'iinspectable.dart';
 import 'ipropertyvalue.dart';
 import 'structs.g.dart';
+import 'types.dart';
 
 /// @nodoc
 const IID_IPropertyValueStatics = '{629bdbc8-d932-4ff4-96b9-8d96c5c1e858}';
@@ -324,7 +325,7 @@ class IPropertyValueStatics extends IInspectable {
     return IPropertyValue.fromRawPointer(retValuePtr);
   }
 
-  Pointer<COMObject> createInspectable(Pointer<COMObject> value) {
+  Pointer<COMObject> createInspectable(Object? value) {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -332,13 +333,14 @@ class IPropertyValueStatics extends IInspectable {
             .cast<
                 Pointer<
                     NativeFunction<
-                        HRESULT Function(Pointer, Pointer<COMObject> value,
-                            Pointer<COMObject>)>>>()
+                        HRESULT Function(
+                            Pointer, LPVTBL value, Pointer<COMObject>)>>>()
             .value
             .asFunction<
-                int Function(
-                    Pointer, Pointer<COMObject> value, Pointer<COMObject>)>()(
-        ptr.ref.lpVtbl, value.cast<Pointer<COMObject>>().value, retValuePtr);
+                int Function(Pointer, LPVTBL value, Pointer<COMObject>)>()(
+        ptr.ref.lpVtbl,
+        value == null ? nullptr : boxValue(value).ref.lpVtbl,
+        retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_foundation/lib/src/ireference.dart
+++ b/packages/windows_foundation/lib/src/ireference.dart
@@ -1,4 +1,6 @@
-// ireference.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
 import 'dart:ffi';
 

--- a/packages/windows_foundation/lib/src/istringable.dart
+++ b/packages/windows_foundation/lib/src/istringable.dart
@@ -18,6 +18,7 @@ import '../../../internal.dart';
 import 'callbacks.dart';
 import 'helpers.dart';
 import 'iinspectable.dart';
+import 'types.dart';
 
 /// @nodoc
 const IID_IStringable = '{96369f54-8eb6-48f0-abce-c1b211e627c3}';

--- a/packages/windows_foundation/lib/src/iuriescapestatics.dart
+++ b/packages/windows_foundation/lib/src/iuriescapestatics.dart
@@ -18,6 +18,7 @@ import '../../../internal.dart';
 import 'callbacks.dart';
 import 'helpers.dart';
 import 'iinspectable.dart';
+import 'types.dart';
 
 /// @nodoc
 const IID_IUriEscapeStatics = '{c1d432ba-c824-4452-a7fd-512bc3bbe9a1}';

--- a/packages/windows_foundation/lib/src/iuriruntimeclass.dart
+++ b/packages/windows_foundation/lib/src/iuriruntimeclass.dart
@@ -18,6 +18,7 @@ import '../../../internal.dart';
 import 'callbacks.dart';
 import 'helpers.dart';
 import 'iinspectable.dart';
+import 'types.dart';
 import 'uri.dart';
 import 'wwwformurldecoder.dart';
 
@@ -397,20 +398,20 @@ class IUriRuntimeClass extends IInspectable {
     final retValuePtr = calloc<Bool>();
 
     try {
-      final hr = ptr.ref.vtable
-              .elementAt(21)
-              .cast<
-                  Pointer<
-                      NativeFunction<
-                          HRESULT Function(Pointer, Pointer<COMObject> pUri,
-                              Pointer<Bool>)>>>()
-              .value
-              .asFunction<
-                  int Function(
-                      Pointer, Pointer<COMObject> pUri, Pointer<Bool>)>()(
-          ptr.ref.lpVtbl,
-          pUri == null ? nullptr : pUri.ptr.cast<Pointer<COMObject>>().value,
-          retValuePtr);
+      final hr =
+          ptr.ref.vtable
+                  .elementAt(21)
+                  .cast<
+                      Pointer<
+                          NativeFunction<
+                              HRESULT Function(
+                                  Pointer, LPVTBL pUri, Pointer<Bool>)>>>()
+                  .value
+                  .asFunction<
+                      int Function(Pointer, LPVTBL pUri, Pointer<Bool>)>()(
+              ptr.ref.lpVtbl,
+              pUri == null ? nullptr : pUri.ptr.ref.lpVtbl,
+              retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/packages/windows_foundation/lib/src/iuriruntimeclassfactory.dart
+++ b/packages/windows_foundation/lib/src/iuriruntimeclassfactory.dart
@@ -18,6 +18,7 @@ import '../../../internal.dart';
 import 'callbacks.dart';
 import 'helpers.dart';
 import 'iinspectable.dart';
+import 'types.dart';
 import 'uri.dart';
 
 /// @nodoc

--- a/packages/windows_foundation/lib/src/iuriruntimeclasswithabsolutecanonicaluri.dart
+++ b/packages/windows_foundation/lib/src/iuriruntimeclasswithabsolutecanonicaluri.dart
@@ -18,6 +18,7 @@ import '../../../internal.dart';
 import 'callbacks.dart';
 import 'helpers.dart';
 import 'iinspectable.dart';
+import 'types.dart';
 
 /// @nodoc
 const IID_IUriRuntimeClassWithAbsoluteCanonicalUri =

--- a/packages/windows_foundation/lib/src/iwwwformurldecoderentry.dart
+++ b/packages/windows_foundation/lib/src/iwwwformurldecoderentry.dart
@@ -18,6 +18,7 @@ import '../../../internal.dart';
 import 'callbacks.dart';
 import 'helpers.dart';
 import 'iinspectable.dart';
+import 'types.dart';
 
 /// @nodoc
 const IID_IWwwFormUrlDecoderEntry = '{125e7431-f678-4e8e-b670-20a9b06c512d}';

--- a/packages/windows_foundation/lib/src/iwwwformurldecoderruntimeclass.dart
+++ b/packages/windows_foundation/lib/src/iwwwformurldecoderruntimeclass.dart
@@ -22,6 +22,7 @@ import 'collections/ivectorview.dart';
 import 'helpers.dart';
 import 'iinspectable.dart';
 import 'iwwwformurldecoderentry.dart';
+import 'types.dart';
 
 /// @nodoc
 const IID_IWwwFormUrlDecoderRuntimeClass =

--- a/packages/windows_foundation/lib/src/iwwwformurldecoderruntimeclassfactory.dart
+++ b/packages/windows_foundation/lib/src/iwwwformurldecoderruntimeclassfactory.dart
@@ -18,6 +18,7 @@ import '../../../internal.dart';
 import 'callbacks.dart';
 import 'helpers.dart';
 import 'iinspectable.dart';
+import 'types.dart';
 import 'wwwformurldecoder.dart';
 
 /// @nodoc

--- a/packages/windows_foundation/lib/src/propertyvalue.dart
+++ b/packages/windows_foundation/lib/src/propertyvalue.dart
@@ -21,6 +21,7 @@ import 'iinspectable.dart';
 import 'ipropertyvalue.dart';
 import 'ipropertyvaluestatics.dart';
 import 'structs.g.dart';
+import 'types.dart';
 
 /// Represents a value in a property store (such as a [PropertySet]
 /// instance).
@@ -188,7 +189,7 @@ class PropertyValue extends IInspectable {
     }
   }
 
-  static Pointer<COMObject> createInspectable(Pointer<COMObject> value) {
+  static Pointer<COMObject> createInspectable(Object? value) {
     final activationFactoryPtr =
         createActivationFactory(_className, IID_IPropertyValueStatics);
     final object = IPropertyValueStatics.fromRawPointer(activationFactoryPtr);

--- a/packages/windows_foundation/lib/src/types.dart
+++ b/packages/windows_foundation/lib/src/types.dart
@@ -1,0 +1,8 @@
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:ffi';
+
+/// An alias for a Pointer to COM vtable.
+typedef LPVTBL = Pointer<Pointer<IntPtr>>;

--- a/packages/windows_foundation/lib/src/uri.dart
+++ b/packages/windows_foundation/lib/src/uri.dart
@@ -23,6 +23,7 @@ import 'iuriescapestatics.dart';
 import 'iuriruntimeclass.dart';
 import 'iuriruntimeclassfactory.dart';
 import 'iuriruntimeclasswithabsolutecanonicaluri.dart';
+import 'types.dart';
 import 'wwwformurldecoder.dart';
 
 /// Defines an object that represents a Uniform Resource Identifier (URI)

--- a/packages/windows_foundation/lib/src/wwwformurldecoder.dart
+++ b/packages/windows_foundation/lib/src/wwwformurldecoder.dart
@@ -24,6 +24,7 @@ import 'iinspectable.dart';
 import 'iwwwformurldecoderentry.dart';
 import 'iwwwformurldecoderruntimeclass.dart';
 import 'iwwwformurldecoderruntimeclassfactory.dart';
+import 'types.dart';
 
 /// Parses a URL query string, and exposes the results as a read-only vector
 /// (list) of name-value pairs from the query string.

--- a/packages/windows_foundation/lib/src/wwwformurldecoderentry.dart
+++ b/packages/windows_foundation/lib/src/wwwformurldecoderentry.dart
@@ -19,6 +19,7 @@ import 'callbacks.dart';
 import 'helpers.dart';
 import 'iinspectable.dart';
 import 'iwwwformurldecoderentry.dart';
+import 'types.dart';
 
 /// Represents a name-value pair in a URL query string.
 ///

--- a/packages/windows_gaming/lib/src/input/igamepadstatics2.dart
+++ b/packages/windows_gaming/lib/src/input/igamepadstatics2.dart
@@ -35,26 +35,20 @@ class IGamepadStatics2 extends IInspectable implements IGamepadStatics {
   Gamepad? fromGameController(IGameController? gameController) {
     final retValuePtr = calloc<COMObject>();
 
-    final hr =
-        ptr
-                .ref.vtable
-                .elementAt(6)
-                .cast<
-                    Pointer<
-                        NativeFunction<
-                            HRESULT Function(
-                                Pointer,
-                                Pointer<COMObject> gameController,
-                                Pointer<COMObject>)>>>()
-                .value
-                .asFunction<
-                    int Function(Pointer, Pointer<COMObject> gameController,
-                        Pointer<COMObject>)>()(
-            ptr.ref.lpVtbl,
-            gameController == null
-                ? nullptr
-                : gameController.ptr.cast<Pointer<COMObject>>().value,
-            retValuePtr);
+    final hr = ptr.ref.vtable
+            .elementAt(6)
+            .cast<
+                Pointer<
+                    NativeFunction<
+                        HRESULT Function(Pointer, LPVTBL gameController,
+                            Pointer<COMObject>)>>>()
+            .value
+            .asFunction<
+                int Function(
+                    Pointer, LPVTBL gameController, Pointer<COMObject>)>()(
+        ptr.ref.lpVtbl,
+        gameController == null ? nullptr : gameController.ptr.ref.lpVtbl,
+        retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_globalization/lib/src/icalendar.dart
+++ b/packages/windows_globalization/lib/src/icalendar.dart
@@ -1801,14 +1801,13 @@ class ICalendar extends IInspectable {
               .cast<
                   Pointer<
                       NativeFunction<
-                          HRESULT Function(Pointer, Pointer<COMObject> other,
-                              Pointer<Int32>)>>>()
+                          HRESULT Function(
+                              Pointer, LPVTBL other, Pointer<Int32>)>>>()
               .value
               .asFunction<
-                  int Function(
-                      Pointer, Pointer<COMObject> other, Pointer<Int32>)>()(
+                  int Function(Pointer, LPVTBL other, Pointer<Int32>)>()(
           ptr.ref.lpVtbl,
-          other == null ? nullptr : other.ptr.cast<Pointer<COMObject>>().value,
+          other == null ? nullptr : other.ptr.ref.lpVtbl,
           retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
@@ -1850,13 +1849,10 @@ class ICalendar extends IInspectable {
     final hr = ptr.ref.vtable
             .elementAt(95)
             .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(Pointer, Pointer<COMObject> other)>>>()
+                Pointer<NativeFunction<HRESULT Function(Pointer, LPVTBL other)>>>()
             .value
-            .asFunction<int Function(Pointer, Pointer<COMObject> other)>()(
-        ptr.ref.lpVtbl,
-        other == null ? nullptr : other.ptr.cast<Pointer<COMObject>>().value);
+            .asFunction<int Function(Pointer, LPVTBL other)>()(
+        ptr.ref.lpVtbl, other == null ? nullptr : other.ptr.ref.lpVtbl);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/packages/windows_globalization/lib/src/icalendarfactory.dart
+++ b/packages/windows_globalization/lib/src/icalendarfactory.dart
@@ -38,13 +38,12 @@ class ICalendarFactory extends IInspectable {
             .cast<
                 Pointer<
                     NativeFunction<
-                        HRESULT Function(Pointer, Pointer<COMObject> languages,
-                            Pointer<COMObject>)>>>()
+                        HRESULT Function(
+                            Pointer, LPVTBL languages, Pointer<COMObject>)>>>()
             .value
             .asFunction<
-                int Function(Pointer, Pointer<COMObject> languages,
-                    Pointer<COMObject>)>()(ptr.ref.lpVtbl,
-        languages.ptr.cast<Pointer<COMObject>>().value, retValuePtr);
+                int Function(Pointer, LPVTBL languages, Pointer<COMObject>)>()(
+        ptr.ref.lpVtbl, languages.ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -69,16 +68,16 @@ class ICalendarFactory extends IInspectable {
                         NativeFunction<
                             HRESULT Function(
                                 Pointer,
-                                Pointer<COMObject> languages,
+                                LPVTBL languages,
                                 IntPtr calendar,
                                 IntPtr clock,
                                 Pointer<COMObject>)>>>()
                 .value
                 .asFunction<
-                    int Function(Pointer, Pointer<COMObject> languages,
-                        int calendar, int clock, Pointer<COMObject>)>()(
+                    int Function(Pointer, LPVTBL languages, int calendar,
+                        int clock, Pointer<COMObject>)>()(
             ptr.ref.lpVtbl,
-            languages.ptr.cast<Pointer<COMObject>>().value,
+            languages.ptr.ref.lpVtbl,
             calendarHString,
             clockHString,
             retValuePtr);

--- a/packages/windows_globalization/lib/src/icalendarfactory2.dart
+++ b/packages/windows_globalization/lib/src/icalendarfactory2.dart
@@ -45,22 +45,17 @@ class ICalendarFactory2 extends IInspectable {
                     NativeFunction<
                         HRESULT Function(
                             Pointer,
-                            Pointer<COMObject> languages,
+                            LPVTBL languages,
                             IntPtr calendar,
                             IntPtr clock,
                             IntPtr timeZoneId,
                             Pointer<COMObject>)>>>()
             .value
             .asFunction<
-                int Function(
-                    Pointer,
-                    Pointer<COMObject> languages,
-                    int calendar,
-                    int clock,
-                    int timeZoneId,
-                    Pointer<COMObject>)>()(
+                int Function(Pointer, LPVTBL languages, int calendar, int clock,
+                    int timeZoneId, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl,
-        languages.ptr.cast<Pointer<COMObject>>().value,
+        languages.ptr.ref.lpVtbl,
         calendarHString,
         clockHString,
         timeZoneIdHString,

--- a/packages/windows_globalization/lib/src/phonenumberformatting/iphonenumberformatter.dart
+++ b/packages/windows_globalization/lib/src/phonenumberformatting/iphonenumberformatter.dart
@@ -40,16 +40,13 @@ class IPhoneNumberFormatter extends IInspectable {
               .cast<
                   Pointer<
                       NativeFunction<
-                          HRESULT Function(Pointer, Pointer<COMObject> number,
-                              Pointer<IntPtr>)>>>()
+                          HRESULT Function(
+                              Pointer, LPVTBL number, Pointer<IntPtr>)>>>()
               .value
               .asFunction<
-                  int Function(
-                      Pointer, Pointer<COMObject> number, Pointer<IntPtr>)>()(
+                  int Function(Pointer, LPVTBL number, Pointer<IntPtr>)>()(
           ptr.ref.lpVtbl,
-          number == null
-              ? nullptr
-              : number.ptr.cast<Pointer<COMObject>>().value,
+          number == null ? nullptr : number.ptr.ref.lpVtbl,
           retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
@@ -72,16 +69,14 @@ class IPhoneNumberFormatter extends IInspectable {
               .cast<
                   Pointer<
                       NativeFunction<
-                          HRESULT Function(Pointer, Pointer<COMObject> number,
+                          HRESULT Function(Pointer, LPVTBL number,
                               Int32 numberFormat, Pointer<IntPtr>)>>>()
               .value
               .asFunction<
-                  int Function(Pointer, Pointer<COMObject> number,
-                      int numberFormat, Pointer<IntPtr>)>()(
+                  int Function(Pointer, LPVTBL number, int numberFormat,
+                      Pointer<IntPtr>)>()(
           ptr.ref.lpVtbl,
-          number == null
-              ? nullptr
-              : number.ptr.cast<Pointer<COMObject>>().value,
+          number == null ? nullptr : number.ptr.ref.lpVtbl,
           numberFormat.value,
           retValuePtr);
 

--- a/packages/windows_globalization/lib/src/phonenumberformatting/iphonenumberinfo.dart
+++ b/packages/windows_globalization/lib/src/phonenumberformatting/iphonenumberinfo.dart
@@ -198,25 +198,19 @@ class IPhoneNumberInfo extends IInspectable {
     final retValuePtr = calloc<Int32>();
 
     try {
-      final hr =
-          ptr.ref.vtable
-                  .elementAt(13)
-                  .cast<
-                      Pointer<
-                          NativeFunction<
-                              HRESULT Function(
-                                  Pointer,
-                                  Pointer<COMObject> otherNumber,
-                                  Pointer<Int32>)>>>()
-                  .value
-                  .asFunction<
-                      int Function(Pointer, Pointer<COMObject> otherNumber,
-                          Pointer<Int32>)>()(
-              ptr.ref.lpVtbl,
-              otherNumber == null
-                  ? nullptr
-                  : otherNumber.ptr.cast<Pointer<COMObject>>().value,
-              retValuePtr);
+      final hr = ptr.ref.vtable
+              .elementAt(13)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          HRESULT Function(
+                              Pointer, LPVTBL otherNumber, Pointer<Int32>)>>>()
+              .value
+              .asFunction<
+                  int Function(Pointer, LPVTBL otherNumber, Pointer<Int32>)>()(
+          ptr.ref.lpVtbl,
+          otherNumber == null ? nullptr : otherNumber.ptr.ref.lpVtbl,
+          retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/packages/windows_networking/lib/src/connectivity/inetworkinformationstatics.dart
+++ b/packages/windows_networking/lib/src/connectivity/inetworkinformationstatics.dart
@@ -1,4 +1,6 @@
-// inetworkinformationstatics.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: unused_import
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
@@ -129,15 +131,12 @@ class INetworkInformationStatics extends IInspectable {
             .cast<
                 Pointer<
                     NativeFunction<
-                        HRESULT Function(Pointer, Pointer<COMObject> uri,
-                            Pointer<COMObject>)>>>()
+                        HRESULT Function(
+                            Pointer, LPVTBL uri, Pointer<COMObject>)>>>()
             .value
             .asFunction<
-                int Function(
-                    Pointer, Pointer<COMObject> uri, Pointer<COMObject>)>()(
-        ptr.ref.lpVtbl,
-        uriUri.ptr.cast<Pointer<COMObject>>().value,
-        retValuePtr);
+                int Function(Pointer, LPVTBL uri, Pointer<COMObject>)>()(
+        ptr.ref.lpVtbl, uriUri.ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -160,19 +159,13 @@ class INetworkInformationStatics extends IInspectable {
             .cast<
                 Pointer<
                     NativeFunction<
-                        HRESULT Function(
-                            Pointer,
-                            Pointer<COMObject> destinationList,
-                            Uint32 sortOptions,
-                            Pointer<COMObject>)>>>()
+                        HRESULT Function(Pointer, LPVTBL destinationList,
+                            Uint32 sortOptions, Pointer<COMObject>)>>>()
             .value
             .asFunction<
-                int Function(Pointer, Pointer<COMObject> destinationList,
-                    int sortOptions, Pointer<COMObject>)>()(
-        ptr.ref.lpVtbl,
-        destinationList.cast<Pointer<COMObject>>().value,
-        sortOptions,
-        retValuePtr);
+                int Function(Pointer, LPVTBL destinationList, int sortOptions,
+                    Pointer<COMObject>)>()(
+        ptr.ref.lpVtbl, destinationList.ref.lpVtbl, sortOptions, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_networking/lib/src/ihostname.dart
+++ b/packages/windows_networking/lib/src/ihostname.dart
@@ -160,16 +160,13 @@ class IHostName extends IInspectable {
               .cast<
                   Pointer<
                       NativeFunction<
-                          HRESULT Function(Pointer, Pointer<COMObject> hostName,
-                              Pointer<Bool>)>>>()
+                          HRESULT Function(
+                              Pointer, LPVTBL hostName, Pointer<Bool>)>>>()
               .value
               .asFunction<
-                  int Function(
-                      Pointer, Pointer<COMObject> hostName, Pointer<Bool>)>()(
+                  int Function(Pointer, LPVTBL hostName, Pointer<Bool>)>()(
           ptr.ref.lpVtbl,
-          hostName == null
-              ? nullptr
-              : hostName.ptr.cast<Pointer<COMObject>>().value,
+          hostName == null ? nullptr : hostName.ptr.ref.lpVtbl,
           retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);

--- a/packages/windows_storage/lib/src/fileproperties/istorageitemextraproperties.dart
+++ b/packages/windows_storage/lib/src/fileproperties/istorageitemextraproperties.dart
@@ -39,18 +39,16 @@ class IStorageItemExtraProperties extends IInspectable {
             .cast<
                 Pointer<
                     NativeFunction<
-                        HRESULT Function(
-                            Pointer,
-                            Pointer<COMObject> propertiesToRetrieve,
+                        HRESULT Function(Pointer, LPVTBL propertiesToRetrieve,
                             Pointer<COMObject>)>>>()
             .value
             .asFunction<
-                int Function(Pointer, Pointer<COMObject> propertiesToRetrieve,
+                int Function(Pointer, LPVTBL propertiesToRetrieve,
                     Pointer<COMObject>)>()(
         ptr.ref.lpVtbl,
         propertiesToRetrieve == null
             ? nullptr
-            : propertiesToRetrieve.ptr.cast<Pointer<COMObject>>().value,
+            : propertiesToRetrieve.ptr.ref.lpVtbl,
         retValuePtr);
 
     if (FAILED(hr)) {
@@ -78,18 +76,14 @@ class IStorageItemExtraProperties extends IInspectable {
             .cast<
                 Pointer<
                     NativeFunction<
-                        HRESULT Function(
-                            Pointer,
-                            Pointer<COMObject> propertiesToSave,
+                        HRESULT Function(Pointer, LPVTBL propertiesToSave,
                             Pointer<COMObject>)>>>()
             .value
             .asFunction<
-                int Function(Pointer, Pointer<COMObject> propertiesToSave,
-                    Pointer<COMObject>)>()(
+                int Function(
+                    Pointer, LPVTBL propertiesToSave, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl,
-        propertiesToSave == null
-            ? nullptr
-            : propertiesToSave.ptr.cast<Pointer<COMObject>>().value,
+        propertiesToSave == null ? nullptr : propertiesToSave.ptr.ref.lpVtbl,
         retValuePtr);
 
     if (FAILED(hr)) {

--- a/packages/windows_storage/lib/src/istoragefile.dart
+++ b/packages/windows_storage/lib/src/istoragefile.dart
@@ -1,4 +1,6 @@
-// istoragefile.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: unused_import
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
@@ -80,21 +82,18 @@ class IStorageFile extends IInspectable implements IStorageItem {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<void>();
 
-    final hr =
-        ptr.ref.vtable
-                .elementAt(13)
-                .cast<
-                    Pointer<
-                        NativeFunction<
-                            HRESULT Function(
-                                Pointer,
-                                Pointer<COMObject> fileToReplace,
-                                Pointer<COMObject>)>>>()
-                .value
-                .asFunction<
-                    int Function(Pointer, Pointer<COMObject> fileToReplace,
-                        Pointer<COMObject>)>()(ptr.ref.lpVtbl,
-            fileToReplace.ptr.cast<Pointer<COMObject>>().value, retValuePtr);
+    final hr = ptr.ref.vtable
+            .elementAt(13)
+            .cast<
+                Pointer<
+                    NativeFunction<
+                        HRESULT Function(Pointer, LPVTBL fileToReplace,
+                            Pointer<COMObject>)>>>()
+            .value
+            .asFunction<
+                int Function(
+                    Pointer, LPVTBL fileToReplace, Pointer<COMObject>)>()(
+        ptr.ref.lpVtbl, fileToReplace.ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -111,21 +110,18 @@ class IStorageFile extends IInspectable implements IStorageItem {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<void>();
 
-    final hr =
-        ptr.ref.vtable
-                .elementAt(17)
-                .cast<
-                    Pointer<
-                        NativeFunction<
-                            HRESULT Function(
-                                Pointer,
-                                Pointer<COMObject> fileToReplace,
-                                Pointer<COMObject>)>>>()
-                .value
-                .asFunction<
-                    int Function(Pointer, Pointer<COMObject> fileToReplace,
-                        Pointer<COMObject>)>()(ptr.ref.lpVtbl,
-            fileToReplace.ptr.cast<Pointer<COMObject>>().value, retValuePtr);
+    final hr = ptr.ref.vtable
+            .elementAt(17)
+            .cast<
+                Pointer<
+                    NativeFunction<
+                        HRESULT Function(Pointer, LPVTBL fileToReplace,
+                            Pointer<COMObject>)>>>()
+            .value
+            .asFunction<
+                int Function(
+                    Pointer, LPVTBL fileToReplace, Pointer<COMObject>)>()(
+        ptr.ref.lpVtbl, fileToReplace.ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_storage/lib/src/istoragefilestatics.dart
+++ b/packages/windows_storage/lib/src/istoragefilestatics.dart
@@ -1,4 +1,6 @@
-// istoragefilestatics.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: unused_import
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
@@ -30,7 +32,7 @@ class IStorageFileStatics extends IInspectable {
   Future<StorageFile?> getFileFromPathAsync(String path) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<StorageFile?>();
-    final pathHstring = convertToHString(path);
+    final pathHString = convertToHString(path);
 
     final hr = ptr.ref.vtable
             .elementAt(6)
@@ -41,14 +43,14 @@ class IStorageFileStatics extends IInspectable {
                             Pointer, IntPtr path, Pointer<COMObject>)>>>()
             .value
             .asFunction<int Function(Pointer, int path, Pointer<COMObject>)>()(
-        ptr.ref.lpVtbl, pathHstring, retValuePtr);
+        ptr.ref.lpVtbl, pathHString, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
     }
 
-    WindowsDeleteString(pathHstring);
+    WindowsDeleteString(pathHString);
 
     final asyncOperation = IAsyncOperation<StorageFile?>.fromRawPointer(
         retValuePtr,
@@ -69,15 +71,12 @@ class IStorageFileStatics extends IInspectable {
             .cast<
                 Pointer<
                     NativeFunction<
-                        HRESULT Function(Pointer, Pointer<COMObject> uri,
-                            Pointer<COMObject>)>>>()
+                        HRESULT Function(
+                            Pointer, LPVTBL uri, Pointer<COMObject>)>>>()
             .value
             .asFunction<
-                int Function(
-                    Pointer, Pointer<COMObject> uri, Pointer<COMObject>)>()(
-        ptr.ref.lpVtbl,
-        uriUri.ptr.cast<Pointer<COMObject>>().value,
-        retValuePtr);
+                int Function(Pointer, LPVTBL uri, Pointer<COMObject>)>()(
+        ptr.ref.lpVtbl, uriUri.ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_storage/lib/src/iuserdatapathsstatics.dart
+++ b/packages/windows_storage/lib/src/iuserdatapathsstatics.dart
@@ -39,14 +39,13 @@ class IUserDataPathsStatics extends IInspectable {
             .cast<
                 Pointer<
                     NativeFunction<
-                        HRESULT Function(Pointer, Pointer<COMObject> user,
-                            Pointer<COMObject>)>>>()
+                        HRESULT Function(
+                            Pointer, LPVTBL user, Pointer<COMObject>)>>>()
             .value
             .asFunction<
-                int Function(
-                    Pointer, Pointer<COMObject> user, Pointer<COMObject>)>()(
+                int Function(Pointer, LPVTBL user, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl,
-        user == null ? nullptr : user.ptr.cast<Pointer<COMObject>>().value,
+        user == null ? nullptr : user.ptr.ref.lpVtbl,
         retValuePtr);
 
     if (FAILED(hr)) {

--- a/packages/windows_storage/lib/src/pickers/ifileopenpickerstatics2.dart
+++ b/packages/windows_storage/lib/src/pickers/ifileopenpickerstatics2.dart
@@ -39,14 +39,13 @@ class IFileOpenPickerStatics2 extends IInspectable {
             .cast<
                 Pointer<
                     NativeFunction<
-                        HRESULT Function(Pointer, Pointer<COMObject> user,
-                            Pointer<COMObject>)>>>()
+                        HRESULT Function(
+                            Pointer, LPVTBL user, Pointer<COMObject>)>>>()
             .value
             .asFunction<
-                int Function(
-                    Pointer, Pointer<COMObject> user, Pointer<COMObject>)>()(
+                int Function(Pointer, LPVTBL user, Pointer<COMObject>)>()(
         ptr.ref.lpVtbl,
-        user == null ? nullptr : user.ptr.cast<Pointer<COMObject>>().value,
+        user == null ? nullptr : user.ptr.ref.lpVtbl,
         retValuePtr);
 
     if (FAILED(hr)) {

--- a/packages/windows_storage/lib/src/storagefile.dart
+++ b/packages/windows_storage/lib/src/storagefile.dart
@@ -1,4 +1,6 @@
-// storagefile.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: unused_import
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names

--- a/packages/windows_ui/lib/src/notifications/inotificationdatafactory.dart
+++ b/packages/windows_ui/lib/src/notifications/inotificationdatafactory.dart
@@ -35,25 +35,18 @@ class INotificationDataFactory extends IInspectable {
       int sequenceNumber) {
     final retValuePtr = calloc<COMObject>();
 
-    final hr =
-        ptr.ref.vtable
-                .elementAt(6)
-                .cast<
-                    Pointer<
-                        NativeFunction<
-                            HRESULT Function(
-                                Pointer,
-                                Pointer<COMObject> initialValues,
-                                Uint32 sequenceNumber,
-                                Pointer<COMObject>)>>>()
-                .value
-                .asFunction<
-                    int Function(Pointer, Pointer<COMObject> initialValues,
-                        int sequenceNumber, Pointer<COMObject>)>()(
-            ptr.ref.lpVtbl,
-            initialValues.ptr.cast<Pointer<COMObject>>().value,
-            sequenceNumber,
-            retValuePtr);
+    final hr = ptr.ref.vtable
+            .elementAt(6)
+            .cast<
+                Pointer<
+                    NativeFunction<
+                        HRESULT Function(Pointer, LPVTBL initialValues,
+                            Uint32 sequenceNumber, Pointer<COMObject>)>>>()
+            .value
+            .asFunction<
+                int Function(Pointer, LPVTBL initialValues, int sequenceNumber,
+                    Pointer<COMObject>)>()(ptr.ref.lpVtbl,
+        initialValues.ptr.ref.lpVtbl, sequenceNumber, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -67,21 +60,18 @@ class INotificationDataFactory extends IInspectable {
       IIterable<IKeyValuePair<String, String>> initialValues) {
     final retValuePtr = calloc<COMObject>();
 
-    final hr =
-        ptr.ref.vtable
-                .elementAt(7)
-                .cast<
-                    Pointer<
-                        NativeFunction<
-                            HRESULT Function(
-                                Pointer,
-                                Pointer<COMObject> initialValues,
-                                Pointer<COMObject>)>>>()
-                .value
-                .asFunction<
-                    int Function(Pointer, Pointer<COMObject> initialValues,
-                        Pointer<COMObject>)>()(ptr.ref.lpVtbl,
-            initialValues.ptr.cast<Pointer<COMObject>>().value, retValuePtr);
+    final hr = ptr.ref.vtable
+            .elementAt(7)
+            .cast<
+                Pointer<
+                    NativeFunction<
+                        HRESULT Function(Pointer, LPVTBL initialValues,
+                            Pointer<COMObject>)>>>()
+            .value
+            .asFunction<
+                int Function(
+                    Pointer, LPVTBL initialValues, Pointer<COMObject>)>()(
+        ptr.ref.lpVtbl, initialValues.ptr.ref.lpVtbl, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_ui/lib/src/notifications/itoastnotification.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotification.dart
@@ -1,13 +1,17 @@
-// itoastnotification.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: unused_import
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 
+import 'dart:async';
 import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
+// import 'package:windows_data/windows_data.dart';
 import 'package:windows_foundation/internal.dart';
 import 'package:windows_foundation/windows_foundation.dart';
 
@@ -25,43 +29,44 @@ class IToastNotification extends IInspectable {
       IToastNotification.fromRawPointer(
           interface.toInterface(IID_IToastNotification));
 
-  Pointer<COMObject> get content {
-    final retValuePtr = calloc<COMObject>();
+  // XmlDocument? get content {
+  //   final retValuePtr = calloc<COMObject>();
 
-    final hr = ptr.ref.vtable
-            .elementAt(6)
-            .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(Pointer, Pointer<COMObject>)>>>()
-            .value
-            .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        ptr.ref.lpVtbl, retValuePtr);
+  //   final hr = ptr.ref.vtable
+  //           .elementAt(6)
+  //           .cast<
+  //               Pointer<
+  //                   NativeFunction<
+  //                       HRESULT Function(Pointer, Pointer<COMObject>)>>>()
+  //           .value
+  //           .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
+  //       ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) {
-      free(retValuePtr);
-      throw WindowsException(hr);
-    }
+  //   if (FAILED(hr)) {
+  //     free(retValuePtr);
+  //     throw WindowsException(hr);
+  //   }
 
-    return retValuePtr;
-  }
+  //   if (retValuePtr.ref.lpVtbl == nullptr) {
+  //     free(retValuePtr);
+  //     return null;
+  //   }
+
+  //   return XmlDocument.fromRawPointer(retValuePtr);
+  // }
 
   set expirationTime(DateTime? value) {
-    final referencePtr = value == null
-        ? calloc<COMObject>()
-        : boxValue(value, convertToIReference: true);
-
     final hr = ptr.ref.vtable
-        .elementAt(7)
-        .cast<Pointer<NativeFunction<HRESULT Function(Pointer, COMObject)>>>()
-        .value
-        .asFunction<
-            int Function(
-                Pointer, COMObject)>()(ptr.ref.lpVtbl, referencePtr.ref);
+            .elementAt(7)
+            .cast<Pointer<NativeFunction<HRESULT Function(Pointer, LPVTBL)>>>()
+            .value
+            .asFunction<int Function(Pointer, LPVTBL)>()(
+        ptr.ref.lpVtbl,
+        value == null
+            ? nullptr
+            : boxValue(value, convertToIReference: true).ref.lpVtbl);
 
     if (FAILED(hr)) throw WindowsException(hr);
-
-    if (value == null) free(referencePtr);
   }
 
   DateTime? get expirationTime {
@@ -82,7 +87,10 @@ class IToastNotification extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) return null;
+    if (retValuePtr.ref.lpVtbl == nullptr) {
+      free(retValuePtr);
+      return null;
+    }
 
     final reference = IReference<DateTime>.fromRawPointer(retValuePtr,
         referenceIid: '{5541d8a7-497c-5aa4-86fc-7713adbf2a2c}');

--- a/packages/windows_ui/lib/src/notifications/itoastnotification2.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotification2.dart
@@ -1,9 +1,12 @@
-// itoastnotification2.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: unused_import
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 
+import 'dart:async';
 import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';

--- a/packages/windows_ui/lib/src/notifications/itoastnotification3.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotification3.dart
@@ -1,9 +1,12 @@
-// itoastnotification3.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: unused_import
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 
+import 'dart:async';
 import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';

--- a/packages/windows_ui/lib/src/notifications/itoastnotification4.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotification4.dart
@@ -1,9 +1,12 @@
-// itoastnotification4.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: unused_import
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 
+import 'dart:async';
 import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
@@ -55,14 +58,10 @@ class IToastNotification4 extends IInspectable {
   set data(NotificationData? value) {
     final hr = ptr.ref.vtable
             .elementAt(7)
-            .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(Pointer, Pointer<COMObject>)>>>()
+            .cast<Pointer<NativeFunction<HRESULT Function(Pointer, LPVTBL)>>>()
             .value
-            .asFunction<int Function(Pointer, Pointer<COMObject>)>()(
-        ptr.ref.lpVtbl,
-        value == null ? nullptr : value.ptr.cast<Pointer<COMObject>>().value);
+            .asFunction<int Function(Pointer, LPVTBL)>()(
+        ptr.ref.lpVtbl, value == null ? nullptr : value.ptr.ref.lpVtbl);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/packages/windows_ui/lib/src/notifications/itoastnotification6.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotification6.dart
@@ -1,9 +1,12 @@
-// itoastnotification6.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: unused_import
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 
+import 'dart:async';
 import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';

--- a/packages/windows_ui/lib/src/notifications/itoastnotificationfactory.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotificationfactory.dart
@@ -1,13 +1,17 @@
-// itoastnotificationfactory.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: unused_import
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 
+import 'dart:async';
 import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
+// import 'package:windows_data/windows_data.dart';
 import 'package:windows_foundation/internal.dart';
 import 'package:windows_foundation/windows_foundation.dart';
 
@@ -25,27 +29,26 @@ class IToastNotificationFactory extends IInspectable {
       IToastNotificationFactory.fromRawPointer(
           interface.toInterface(IID_IToastNotificationFactory));
 
-  Pointer<COMObject> createToastNotification(Pointer<COMObject> content) {
-    final retValuePtr = calloc<COMObject>();
+  // ToastNotification createToastNotification(XmlDocument content) {
+  //   final retValuePtr = calloc<COMObject>();
 
-    final hr = ptr.ref.vtable
-            .elementAt(6)
-            .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(Pointer, Pointer<COMObject> content,
-                            Pointer<COMObject>)>>>()
-            .value
-            .asFunction<
-                int Function(
-                    Pointer, Pointer<COMObject> content, Pointer<COMObject>)>()(
-        ptr.ref.lpVtbl, content.cast<Pointer<COMObject>>().value, retValuePtr);
+  //   final hr = ptr.ref.vtable
+  //           .elementAt(6)
+  //           .cast<
+  //               Pointer<
+  //                   NativeFunction<
+  //                       HRESULT Function(
+  //                           Pointer, LPVTBL content, Pointer<COMObject>)>>>()
+  //           .value
+  //           .asFunction<
+  //               int Function(Pointer, LPVTBL content, Pointer<COMObject>)>()(
+  //       ptr.ref.lpVtbl, content.ptr.ref.lpVtbl, retValuePtr);
 
-    if (FAILED(hr)) {
-      free(retValuePtr);
-      throw WindowsException(hr);
-    }
+  //   if (FAILED(hr)) {
+  //     free(retValuePtr);
+  //     throw WindowsException(hr);
+  //   }
 
-    return retValuePtr;
-  }
+  //   return ToastNotification.fromRawPointer(retValuePtr);
+  // }
 }

--- a/packages/windows_ui/lib/src/notifications/itoastnotificationmanagerstatics.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotificationmanagerstatics.dart
@@ -1,4 +1,6 @@
-// itoastnotificationmanagerstatics.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: unused_import
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
@@ -50,7 +52,8 @@ class IToastNotificationManagerStatics extends IInspectable {
 
   Pointer<COMObject> createToastNotifierWithId(String applicationId) {
     final retValuePtr = calloc<COMObject>();
-    final applicationIdHstring = convertToHString(applicationId);
+    final applicationIdHString = convertToHString(applicationId);
+
     final hr = ptr.ref.vtable
             .elementAt(7)
             .cast<
@@ -61,13 +64,13 @@ class IToastNotificationManagerStatics extends IInspectable {
             .value
             .asFunction<
                 int Function(Pointer, int applicationId, Pointer<COMObject>)>()(
-        ptr.ref.lpVtbl, applicationIdHstring, retValuePtr);
+        ptr.ref.lpVtbl, applicationIdHString, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
     }
-    WindowsDeleteString(applicationIdHstring);
+    WindowsDeleteString(applicationIdHString);
     return retValuePtr;
   }
 

--- a/packages/windows_ui/lib/src/notifications/toastnotification.dart
+++ b/packages/windows_ui/lib/src/notifications/toastnotification.dart
@@ -1,13 +1,17 @@
-// toastnotification.dart
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: unused_import
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 
+import 'dart:async';
 import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
+// import 'package:windows_data/windows_data.dart';
 import 'package:windows_foundation/internal.dart';
 import 'package:windows_foundation/windows_foundation.dart';
 
@@ -33,28 +37,27 @@ class ToastNotification extends IInspectable
         IToastNotification6 {
   ToastNotification.fromRawPointer(super.ptr);
 
-  static const _className = 'Windows.UI.Notifications.ToastNotification';
+  // static const _className = 'Windows.UI.Notifications.ToastNotification';
 
   // IToastNotificationFactory methods
-  static ToastNotification createToastNotification(Pointer<COMObject> content) {
-    final activationFactoryPtr =
-        createActivationFactory(_className, IID_IToastNotificationFactory);
-    final object =
-        IToastNotificationFactory.fromRawPointer(activationFactoryPtr);
+  // static ToastNotification createToastNotification(XmlDocument content) {
+  //   final activationFactoryPtr =
+  //       createActivationFactory(_className, IID_IToastNotificationFactory);
+  //   final object =
+  //       IToastNotificationFactory.fromRawPointer(activationFactoryPtr);
 
-    try {
-      final result = object.createToastNotification(content);
-      return ToastNotification.fromRawPointer(result);
-    } finally {
-      object.release();
-    }
-  }
+  //   try {
+  //     return object.createToastNotification(content);
+  //   } finally {
+  //     object.release();
+  //   }
+  // }
 
   // IToastNotification methods
   late final _iToastNotification = IToastNotification.from(this);
 
-  @override
-  Pointer<COMObject> get content => _iToastNotification.content;
+  // @override
+  // XmlDocument? get content => _iToastNotification.content;
 
   @override
   set expirationTime(DateTime? value) =>

--- a/packages/winrtgen/lib/src/declarations/class_or_interface.dart
+++ b/packages/winrtgen/lib/src/declarations/class_or_interface.dart
@@ -120,7 +120,7 @@ class WinRTClassOrInterfaceSetterProjection extends WinRTSetPropertyProjection
   @override
   String toString() => '''
       set $exposedMethodName(${parameters.first.type.methodParamType} value) {
-        ${ffiCall(params: 'value == null ? calloc<COMObject>() : value.ptr.cast<Pointer<COMObject>>().value')}
+        ${ffiCall(params: 'value == null ? nullptr : value.ptr.ref.lpVtbl')}
       }
   ''';
 }
@@ -142,12 +142,16 @@ class WinRTClassOrInterfaceParameterProjection
       return paramType == 'Pointer<COMObject>' ? identifier : '$identifier.ptr';
     }
 
-    if (paramType == 'Pointer<COMObject>') {
-      return '$name.cast<Pointer<COMObject>>().value';
+    if (paramType == 'Object?') {
+      return '$name == null ? nullptr : boxValue($name).ref.lpVtbl';
     }
 
-    return paramType.endsWith('?')
-        ? '$name == null ? nullptr : $name.ptr.cast<Pointer<COMObject>>().value'
-        : '$name.ptr.cast<Pointer<COMObject>>().value';
+    if (type.nativeType == 'LPVTBL') {
+      return paramType.endsWith('?')
+          ? '$name == null ? nullptr : $name.ptr.ref.lpVtbl'
+          : '$name.ptr.ref.lpVtbl';
+    }
+
+    return '';
   }
 }

--- a/packages/winrtgen/lib/src/declarations/reference.dart
+++ b/packages/winrtgen/lib/src/declarations/reference.dart
@@ -141,7 +141,7 @@ class WinRTReferenceSetterProjection extends WinRTSetPropertyProjection
   @override
   String toString() => '''
       set $exposedMethodName($referenceTypeArgFromParameter? value) {
-        ${ffiCall(params: 'value == null ? calloc<COMObject>() : $boxValueMethodCall.cast<Pointer<COMObject>>().value')}
+        ${ffiCall(params: 'value == null ? nullptr : $boxValueMethodCall.ref.lpVtbl')}
       }
   ''';
 }
@@ -175,7 +175,7 @@ class WinRTReferenceParameterProjection extends WinRTParameterProjection {
     final valueArg = typeProjection.isWinRTEnum ? '$name.value' : name;
     return '''
         $name == null
-            ? calloc<COMObject>()
-            : boxValue($valueArg, ${args.join(', ')}).cast<Pointer<COMObject>>().value''';
+            ? nullptr
+            : boxValue($valueArg, ${args.join(', ')}).ref.lpVtbl''';
   }
 }

--- a/packages/winrtgen/lib/src/declarations/uri.dart
+++ b/packages/winrtgen/lib/src/declarations/uri.dart
@@ -104,6 +104,6 @@ class WinRTUriParameterProjection extends WinRTParameterProjection {
 
   @override
   String get localIdentifier => !methodBelongsToUriRuntimeClass
-      ? '${name}Uri == null ? nullptr : ${name}Uri.ptr.cast<Pointer<COMObject>>().value'
-      : '$name == null ? nullptr : $name.ptr.cast<Pointer<COMObject>>().value';
+      ? '${name}Uri == null ? nullptr : ${name}Uri.ptr.ref.lpVtbl'
+      : '$name == null ? nullptr : $name.ptr.ref.lpVtbl';
 }

--- a/packages/winrtgen/lib/src/winrt_interface.dart
+++ b/packages/winrtgen/lib/src/winrt_interface.dart
@@ -110,7 +110,8 @@ class WinRTInterfaceProjection extends ComInterfaceProjection {
           relativePathTo('../internal.dart'),
           relativePathTo('packages/windows_foundation/callbacks.dart'),
           relativePathTo('packages/windows_foundation/helpers.dart'),
-          relativePathTo('packages/windows_foundation/iinspectable.dart')
+          relativePathTo('packages/windows_foundation/iinspectable.dart'),
+          relativePathTo('packages/windows_foundation/types.dart')
         ] else ...[
           'package:windows_foundation/internal.dart',
           'package:windows_foundation/windows_foundation.dart',

--- a/packages/winrtgen/lib/src/winrt_method.dart
+++ b/packages/winrtgen/lib/src/winrt_method.dart
@@ -24,8 +24,8 @@ import 'winrt_type.dart';
 class WinRTMethodProjection extends MethodProjection {
   WinRTMethodProjection(super.method, super.vtableOffset) {
     parameters = method.parameters
-        .map((param) => WinRTParameterProjection(
-            method, param.name, WinRTTypeProjection(param.typeIdentifier)))
+        .map((param) => WinRTParameterProjection(method, param.name,
+            WinRTTypeProjection(param.typeIdentifier, isParameter: true)))
         .toList();
     returnType = WinRTTypeProjection(method.returnType.typeIdentifier);
   }

--- a/packages/winrtgen/lib/src/winrt_parameter.dart
+++ b/packages/winrtgen/lib/src/winrt_parameter.dart
@@ -62,7 +62,8 @@ class WinRTParameterProjection extends ParameterProjection {
 
   // Matcher properties
 
-  bool get isClassOrInterface => ['Pointer<COMObject>'].contains(type.dartType);
+  bool get isClassOrInterface =>
+      !isObject && ['LPVTBL', 'Pointer<COMObject>'].contains(type.dartType);
 
   bool get isDateTime =>
       type.typeIdentifier.name == 'Windows.Foundation.DateTime';
@@ -85,7 +86,7 @@ class WinRTParameterProjection extends ParameterProjection {
 
   /// Returns the appropriate projection for the parameter.
   WinRTParameterProjection? get parameterProjection {
-    if (isClassOrInterface) {
+    if (isObject || isClassOrInterface) {
       if (isReference) {
         return WinRTReferenceParameterProjection(method, name, type);
       }

--- a/packages/winrtgen/lib/src/winrt_set_property.dart
+++ b/packages/winrtgen/lib/src/winrt_set_property.dart
@@ -43,7 +43,7 @@ class WinRTSetPropertyProjection extends WinRTPropertyProjection {
   // Matcher properties
 
   bool get isClassOrInterfaceProperty =>
-      ['Pointer<COMObject>'].contains(parameters.first.type.dartType);
+      ['LPVTBL', 'Pointer<COMObject>'].contains(parameters.first.type.dartType);
 
   bool get isDateTimeProperty =>
       parameters.first.type.typeIdentifier.name ==

--- a/packages/winrtgen/lib/src/winrt_type.dart
+++ b/packages/winrtgen/lib/src/winrt_type.dart
@@ -20,10 +20,13 @@ const Map<String, TypeTuple> specialTypes = {
 };
 
 class WinRTTypeProjection extends TypeProjection {
-  WinRTTypeProjection(TypeIdentifier ti)
+  WinRTTypeProjection(TypeIdentifier ti, {this.isParameter = false})
       : super(ti.baseType == BaseType.genericTypeModifier
             ? ti.copyWith(name: parseGenericTypeIdentifierName(ti))
             : ti);
+
+  /// Whether this type belongs to a parameter.
+  final bool isParameter;
 
   bool get isWinRTSpecialType =>
       specialTypes.keys.contains(typeIdentifier.name);
@@ -134,10 +137,11 @@ class WinRTTypeProjection extends TypeProjection {
     if (isReferenceType) return unwrapReferenceType();
 
     if (isClass || isInterface || isObject) {
-      const type = 'Pointer<COMObject>';
+      final type = isParameter ? 'LPVTBL' : 'Pointer<COMObject>';
       return TypeTuple(type, type,
-          methodParamType:
-              isObject ? null : nullable(lastComponent(typeIdentifier.name)));
+          methodParamType: isObject
+              ? 'Object?'
+              : nullable(lastComponent(typeIdentifier.name)));
     }
 
     // default: return the name as returned by metadata

--- a/packages/winrtgen/test/goldens/icalendar.golden
+++ b/packages/winrtgen/test/goldens/icalendar.golden
@@ -1801,14 +1801,13 @@ class ICalendar extends IInspectable {
               .cast<
                   Pointer<
                       NativeFunction<
-                          HRESULT Function(Pointer, Pointer<COMObject> other,
-                              Pointer<Int32>)>>>()
+                          HRESULT Function(
+                              Pointer, LPVTBL other, Pointer<Int32>)>>>()
               .value
               .asFunction<
-                  int Function(
-                      Pointer, Pointer<COMObject> other, Pointer<Int32>)>()(
+                  int Function(Pointer, LPVTBL other, Pointer<Int32>)>()(
           ptr.ref.lpVtbl,
-          other == null ? nullptr : other.ptr.cast<Pointer<COMObject>>().value,
+          other == null ? nullptr : other.ptr.ref.lpVtbl,
           retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
@@ -1850,13 +1849,10 @@ class ICalendar extends IInspectable {
     final hr = ptr.ref.vtable
             .elementAt(95)
             .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(Pointer, Pointer<COMObject> other)>>>()
+                Pointer<NativeFunction<HRESULT Function(Pointer, LPVTBL other)>>>()
             .value
-            .asFunction<int Function(Pointer, Pointer<COMObject> other)>()(
-        ptr.ref.lpVtbl,
-        other == null ? nullptr : other.ptr.cast<Pointer<COMObject>>().value);
+            .asFunction<int Function(Pointer, LPVTBL other)>()(
+        ptr.ref.lpVtbl, other == null ? nullptr : other.ptr.ref.lpVtbl);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/packages/winrtgen/test/winrt_projection_test.dart
+++ b/packages/winrtgen/test/winrt_projection_test.dart
@@ -423,15 +423,23 @@ void main() {
     final expirationTimeProjection = projection.methodProjections
         .firstWhere((m) => m.name == 'put_ExpirationTime');
 
-    expect(
-        expirationTimeProjection.nativePrototype,
-        equalsIgnoringWhitespace(
-            'HRESULT Function(Pointer, Pointer<COMObject>)'));
+    expect(expirationTimeProjection.nativePrototype,
+        equalsIgnoringWhitespace('HRESULT Function(Pointer, LPVTBL)'));
     expect(expirationTimeProjection.dartPrototype,
-        equalsIgnoringWhitespace('int Function(Pointer, Pointer<COMObject>)'));
+        equalsIgnoringWhitespace('int Function(Pointer, LPVTBL)'));
     expect(expirationTimeProjection.returnType.dartType, equals('void'));
     expect(expirationTimeProjection.toString().trimLeft(),
         startsWith('set expirationTime(DateTime? value)'));
+
+    final expirationTimeParamProjection =
+        expirationTimeProjection.parameters.first as WinRTParameterProjection;
+
+    expect(expirationTimeParamProjection.preamble, isEmpty);
+    expect(expirationTimeParamProjection.postamble, isEmpty);
+    expect(
+        expirationTimeParamProjection.localIdentifier,
+        equalsIgnoringWhitespace(
+            'value == null ? nullptr : boxValue(value, convertToIReference: true).ref.lpVtbl'));
   });
 
   test('WinRT set property projects WinRT object parameter as nullable', () {
@@ -441,22 +449,22 @@ void main() {
     final projection = WinRTInterfaceProjection(winTypeDef!);
     final dataProjection =
         projection.methodProjections.firstWhere((m) => m.name == 'put_Data');
-    final dataPropertyProjection =
-        WinRTSetPropertyProjection(dataProjection.method, 0);
 
-    expect(
-        dataProjection.nativePrototype,
-        equalsIgnoringWhitespace(
-            'HRESULT Function(Pointer, Pointer<COMObject>)'));
+    expect(dataProjection.nativePrototype,
+        equalsIgnoringWhitespace('HRESULT Function(Pointer, LPVTBL)'));
     expect(dataProjection.dartPrototype,
-        equalsIgnoringWhitespace('int Function(Pointer, Pointer<COMObject>)'));
+        equalsIgnoringWhitespace('int Function(Pointer, LPVTBL)'));
     expect(dataProjection.returnType.dartType, equals('void'));
     expect(dataProjection.toString().trimLeft(),
         startsWith('set data(NotificationData? value)'));
-    expect(
-        dataPropertyProjection.toString(),
-        contains(
-            'value == null ? calloc<COMObject>() : value.ptr.cast<Pointer<COMObject>>().value'));
+
+    final dataParamProjection =
+        dataProjection.parameters.first as WinRTParameterProjection;
+
+    expect(dataParamProjection.preamble, isEmpty);
+    expect(dataParamProjection.postamble, isEmpty);
+    expect(dataParamProjection.localIdentifier,
+        equals('value == null ? nullptr : value.ptr.ref.lpVtbl'));
   });
 
   test(
@@ -469,15 +477,23 @@ void main() {
     final flagsProjection =
         projection.methodProjections.firstWhere((m) => m.name == 'put_Flags');
 
-    expect(
-        flagsProjection.nativePrototype,
-        equalsIgnoringWhitespace(
-            'HRESULT Function(Pointer, Pointer<COMObject>)'));
+    expect(flagsProjection.nativePrototype,
+        equalsIgnoringWhitespace('HRESULT Function(Pointer, LPVTBL)'));
     expect(flagsProjection.dartPrototype,
-        equalsIgnoringWhitespace('int Function(Pointer, Pointer<COMObject>)'));
+        equalsIgnoringWhitespace('int Function(Pointer, LPVTBL)'));
     expect(flagsProjection.returnType.dartType, equals('void'));
     expect(flagsProjection.toString().trimLeft(),
         startsWith('set flags(BluetoothLEAdvertisementFlags? value)'));
+
+    final flagsParamProjection =
+        flagsProjection.parameters.first as WinRTParameterProjection;
+
+    expect(flagsParamProjection.preamble, isEmpty);
+    expect(flagsParamProjection.postamble, isEmpty);
+    expect(
+        flagsParamProjection.localIdentifier,
+        equalsIgnoringWhitespace(
+            'value == null ? nullptr : boxValue(value.value, convertToIReference: true, nativeType: Uint32).ref.lpVtbl'));
   });
 
   test('WinRT method projects DateTime parameter correctly', () {
@@ -522,7 +538,7 @@ void main() {
     expect(initialValuesParameter.preamble, isEmpty);
     expect(initialValuesParameter.postamble, isEmpty);
     expect(initialValuesParameter.localIdentifier,
-        equals('initialValues.ptr.cast<Pointer<COMObject>>().value'));
+        equals('initialValues.ptr.ref.lpVtbl'));
     expect(initialValuesParameter.type.methodParamType,
         equals('IIterable<IKeyValuePair<String, String>>?'));
   });
@@ -734,18 +750,27 @@ void main() {
     final projection = WinRTInterfaceProjection(winTypeDef!);
     final fallbackUriProjection = projection.methodProjections
         .firstWhere((m) => m.name == 'put_FallbackUri');
-    expect(
-        fallbackUriProjection.nativePrototype,
-        equalsIgnoringWhitespace(
-            'HRESULT Function(Pointer, Pointer<COMObject>)'));
+
+    expect(fallbackUriProjection.nativePrototype,
+        equalsIgnoringWhitespace('HRESULT Function(Pointer, LPVTBL)'));
     expect(fallbackUriProjection.dartPrototype,
-        equalsIgnoringWhitespace('int Function(Pointer, Pointer<COMObject>)'));
+        equalsIgnoringWhitespace('int Function(Pointer, LPVTBL)'));
     expect(fallbackUriProjection.toString().trimLeft(),
         startsWith('set fallbackUri(Uri? value)'));
+
+    final fallbackUriParamProjection =
+        fallbackUriProjection.parameters.first as WinRTParameterProjection;
+
     expect(
-        fallbackUriProjection.toString().trimLeft(),
-        contains(
-            'final winrtUri = value == null ? null : winrt_uri.Uri.createUri(value.toString());'));
+        fallbackUriParamProjection.preamble,
+        equalsIgnoringWhitespace(
+            'final valueUri = value == null ? null : winrt_uri.Uri.createUri(value.toString());'));
+    expect(fallbackUriParamProjection.postamble,
+        equalsIgnoringWhitespace('valueUri?.release();'));
+    expect(
+        fallbackUriParamProjection.localIdentifier,
+        equalsIgnoringWhitespace(
+            'valueUri == null ? nullptr : valueUri.ptr.ref.lpVtbl'));
   });
 
   test('WinRT method successfully projects Uri parameter', () {
@@ -762,10 +787,8 @@ void main() {
         equals(
             'final uriUri = uri == null ? null : winrt_uri.Uri.createUri(uri.toString());'));
     expect(uriParameter.postamble, equals('uriUri?.release();'));
-    expect(
-        uriParameter.localIdentifier,
-        equals(
-            'uriUri == null ? nullptr : uriUri.ptr.cast<Pointer<COMObject>>().value'));
+    expect(uriParameter.localIdentifier,
+        equals('uriUri == null ? nullptr : uriUri.ptr.ref.lpVtbl'));
     expect(uriParameter.type.methodParamType, equals('Uri?'));
   });
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

Changes the way WinRT class/interface parameters are passed internally to WinRT APIs. 

This PR introduces a type alias `LPVTBL` (a Pointer to COM vtable). When a WinRT class/interface parameter is projected, the `LPVTBL` is used as its `dartType` and `nativeType`. 

With this, we get rid of the calls to `.cast` on the Pointer (e.g. `value.ptr.cast<Pointer<COMObject>>().value`) while doing the FFI call and also get rid of unnecessary `COMObject` allocations for `null` arguments.

Also contains various documentation fixes.

## Related Issue

None

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
