### PR TITLE
Convert struct fields to `camelCase`

### DIFF
--- a/packages/windows_devices/lib/src/geolocation/structs.g.dart
+++ b/packages/windows_devices/lib/src/geolocation/structs.g.dart
@@ -21,11 +21,11 @@ import 'package:ffi/ffi.dart';
 /// {@category struct}
 class BasicGeoposition extends Struct {
   @Double()
-  external double Latitude;
+  external double latitude;
 
   @Double()
-  external double Longitude;
+  external double longitude;
 
   @Double()
-  external double Altitude;
+  external double altitude;
 }

--- a/packages/windows_foundation/lib/src/numerics/structs.g.dart
+++ b/packages/windows_foundation/lib/src/numerics/structs.g.dart
@@ -21,22 +21,22 @@ import 'package:ffi/ffi.dart';
 /// {@category struct}
 class Matrix3x2 extends Struct {
   @Float()
-  external double M11;
+  external double m11;
 
   @Float()
-  external double M12;
+  external double m12;
 
   @Float()
-  external double M21;
+  external double m21;
 
   @Float()
-  external double M22;
+  external double m22;
 
   @Float()
-  external double M31;
+  external double m31;
 
   @Float()
-  external double M32;
+  external double m32;
 }
 
 /// Describes a 4*4 floating point matrix.
@@ -44,62 +44,62 @@ class Matrix3x2 extends Struct {
 /// {@category struct}
 class Matrix4x4 extends Struct {
   @Float()
-  external double M11;
+  external double m11;
 
   @Float()
-  external double M12;
+  external double m12;
 
   @Float()
-  external double M13;
+  external double m13;
 
   @Float()
-  external double M14;
+  external double m14;
 
   @Float()
-  external double M21;
+  external double m21;
 
   @Float()
-  external double M22;
+  external double m22;
 
   @Float()
-  external double M23;
+  external double m23;
 
   @Float()
-  external double M24;
+  external double m24;
 
   @Float()
-  external double M31;
+  external double m31;
 
   @Float()
-  external double M32;
+  external double m32;
 
   @Float()
-  external double M33;
+  external double m33;
 
   @Float()
-  external double M34;
+  external double m34;
 
   @Float()
-  external double M41;
+  external double m41;
 
   @Float()
-  external double M42;
+  external double m42;
 
   @Float()
-  external double M43;
+  external double m43;
 
   @Float()
-  external double M44;
+  external double m44;
 }
 
 /// Describes a plane (a flat, two-dimensional surface).
 ///
 /// {@category struct}
 class Plane extends Struct {
-  external Vector3 Normal;
+  external Vector3 normal;
 
   @Float()
-  external double D;
+  external double d;
 }
 
 /// Describes a quaternion, which is an abstract representation of an
@@ -108,16 +108,16 @@ class Plane extends Struct {
 /// {@category struct}
 class Quaternion extends Struct {
   @Float()
-  external double X;
+  external double x;
 
   @Float()
-  external double Y;
+  external double y;
 
   @Float()
-  external double Z;
+  external double z;
 
   @Float()
-  external double W;
+  external double w;
 }
 
 /// Describes a number that can be created by the division of 2 integers.
@@ -125,10 +125,10 @@ class Quaternion extends Struct {
 /// {@category struct}
 class Rational extends Struct {
   @Uint32()
-  external int Numerator;
+  external int numerator;
 
   @Uint32()
-  external int Denominator;
+  external int denominator;
 }
 
 /// Describes a vector of two floating-point components.
@@ -136,10 +136,10 @@ class Rational extends Struct {
 /// {@category struct}
 class Vector2 extends Struct {
   @Float()
-  external double X;
+  external double x;
 
   @Float()
-  external double Y;
+  external double y;
 }
 
 /// Describes a vector of three floating-point components.
@@ -147,13 +147,13 @@ class Vector2 extends Struct {
 /// {@category struct}
 class Vector3 extends Struct {
   @Float()
-  external double X;
+  external double x;
 
   @Float()
-  external double Y;
+  external double y;
 
   @Float()
-  external double Z;
+  external double z;
 }
 
 /// Describes a vector of four floating-point components.
@@ -161,14 +161,14 @@ class Vector3 extends Struct {
 /// {@category struct}
 class Vector4 extends Struct {
   @Float()
-  external double X;
+  external double x;
 
   @Float()
-  external double Y;
+  external double y;
 
   @Float()
-  external double Z;
+  external double z;
 
   @Float()
-  external double W;
+  external double w;
 }

--- a/packages/windows_foundation/lib/src/structs.g.dart
+++ b/packages/windows_foundation/lib/src/structs.g.dart
@@ -22,10 +22,10 @@ import 'package:ffi/ffi.dart';
 /// {@category struct}
 class Point extends Struct {
   @Float()
-  external double X;
+  external double x;
 
   @Float()
-  external double Y;
+  external double y;
 }
 
 /// Describes the width, height, and point origin of a rectangle.
@@ -33,16 +33,16 @@ class Point extends Struct {
 /// {@category struct}
 class Rect extends Struct {
   @Float()
-  external double X;
+  external double x;
 
   @Float()
-  external double Y;
+  external double y;
 
   @Float()
-  external double Width;
+  external double width;
 
   @Float()
-  external double Height;
+  external double height;
 }
 
 /// Describes the width and height of an object.
@@ -50,8 +50,8 @@ class Rect extends Struct {
 /// {@category struct}
 class Size extends Struct {
   @Float()
-  external double Width;
+  external double width;
 
   @Float()
-  external double Height;
+  external double height;
 }

--- a/packages/windows_foundation/test/collections_test.dart
+++ b/packages/windows_foundation/test/collections_test.dart
@@ -26,16 +26,16 @@ void main() {
         allocator = Arena();
         final guid = Guid.parse(IID_ISpVoice);
         final pPoint = allocator<Point>()
-          ..ref.X = 3
-          ..ref.Y = -3;
+          ..ref.x = 3
+          ..ref.y = -3;
         final pRect = allocator<Rect>()
-          ..ref.Height = 100
-          ..ref.Width = 200
-          ..ref.X = 2
-          ..ref.Y = -2;
+          ..ref.height = 100
+          ..ref.width = 200
+          ..ref.x = 2
+          ..ref.y = -2;
         final pSize = allocator<Size>()
-          ..ref.Height = 1500
-          ..ref.Width = 300;
+          ..ref.height = 1500
+          ..ref.width = 300;
 
         map = IMap()
           ..insert('key1', null)
@@ -117,22 +117,22 @@ void main() {
         final pointVal = map.lookup('key9');
         expect(pointVal, isA<Point>());
         final point = pointVal as Point;
-        expect(point.X, equals(3));
-        expect(point.Y, equals(-3));
+        expect(point.x, equals(3));
+        expect(point.y, equals(-3));
 
         final rectVal = map.lookup('key10');
         expect(rectVal, isA<Rect>());
         final rect = rectVal as Rect;
-        expect(rect.Height, equals(100));
-        expect(rect.Width, equals(200));
-        expect(rect.X, equals(2));
-        expect(rect.Y, equals(-2));
+        expect(rect.height, equals(100));
+        expect(rect.width, equals(200));
+        expect(rect.x, equals(2));
+        expect(rect.y, equals(-2));
 
         final sizeVal = map.lookup('key11');
         expect(sizeVal, isA<Size>());
         final size = sizeVal as Size;
-        expect(size.Height, equals(1500));
-        expect(size.Width, equals(300));
+        expect(size.height, equals(1500));
+        expect(size.width, equals(300));
 
         expect(map.lookup('key12'), equals('strVal'));
 
@@ -167,22 +167,22 @@ void main() {
         final pointListVal = map.lookup('key20');
         expect(pointListVal, isA<List<Point>>());
         final pointList = pointListVal as List<Point>;
-        expect(pointList.first.X, equals(3));
-        expect(pointList.first.Y, equals(-3));
+        expect(pointList.first.x, equals(3));
+        expect(pointList.first.y, equals(-3));
 
         final rectListVal = map.lookup('key21');
         expect(rectListVal, isA<List<Rect>>());
         final rectList = rectListVal as List<Rect>;
-        expect(rectList.first.Height, equals(100));
-        expect(rectList.first.Width, equals(200));
-        expect(rectList.first.X, equals(2));
-        expect(rectList.first.Y, equals(-2));
+        expect(rectList.first.height, equals(100));
+        expect(rectList.first.width, equals(200));
+        expect(rectList.first.x, equals(2));
+        expect(rectList.first.y, equals(-2));
 
         final sizeListVal = map.lookup('key22');
         expect(sizeListVal, isA<List<Size>>());
         final sizeList = sizeListVal as List<Size>;
-        expect(sizeList.first.Height, equals(1500));
-        expect(sizeList.first.Width, equals(300));
+        expect(sizeList.first.height, equals(1500));
+        expect(sizeList.first.width, equals(300));
 
         expect(map.lookup('key23'), equals(['str1', 'str2']));
       });
@@ -283,16 +283,16 @@ void main() {
           ..insert('key1', null)
           ..insert('key2', 'strVal');
         final pPoint = allocator<Point>()
-          ..ref.X = 3
-          ..ref.Y = -3;
+          ..ref.x = 3
+          ..ref.y = -3;
         final pRect = allocator<Rect>()
-          ..ref.Height = 100
-          ..ref.Width = 200
-          ..ref.X = 2
-          ..ref.Y = -2;
+          ..ref.height = 100
+          ..ref.width = 200
+          ..ref.x = 2
+          ..ref.y = -2;
         final pSize = allocator<Size>()
-          ..ref.Height = 1500
-          ..ref.Width = 300;
+          ..ref.height = 1500
+          ..ref.width = 300;
 
         map = ValueSet()
           ..insert('key1', null)
@@ -363,22 +363,22 @@ void main() {
         final pointVal = map.lookup('key9');
         expect(pointVal, isA<Point>());
         final point = pointVal as Point;
-        expect(point.X, equals(3));
-        expect(point.Y, equals(-3));
+        expect(point.x, equals(3));
+        expect(point.y, equals(-3));
 
         final rectVal = map.lookup('key10');
         expect(rectVal, isA<Rect>());
         final rect = rectVal as Rect;
-        expect(rect.Height, equals(100));
-        expect(rect.Width, equals(200));
-        expect(rect.X, equals(2));
-        expect(rect.Y, equals(-2));
+        expect(rect.height, equals(100));
+        expect(rect.width, equals(200));
+        expect(rect.x, equals(2));
+        expect(rect.y, equals(-2));
 
         final sizeVal = map.lookup('key11');
         expect(sizeVal, isA<Size>());
         final size = sizeVal as Size;
-        expect(size.Height, equals(1500));
-        expect(size.Width, equals(300));
+        expect(size.height, equals(1500));
+        expect(size.width, equals(300));
 
         expect(map.lookup('key12'), equals('strVal'));
 
@@ -407,22 +407,22 @@ void main() {
         final pointListVal = map.lookup('key19');
         expect(pointListVal, isA<List<Point>>());
         final pointList = pointListVal as List<Point>;
-        expect(pointList.first.X, equals(3));
-        expect(pointList.first.Y, equals(-3));
+        expect(pointList.first.x, equals(3));
+        expect(pointList.first.y, equals(-3));
 
         final rectListVal = map.lookup('key20');
         expect(rectListVal, isA<List<Rect>>());
         final rectList = rectListVal as List<Rect>;
-        expect(rectList.first.Height, equals(100));
-        expect(rectList.first.Width, equals(200));
-        expect(rectList.first.X, equals(2));
-        expect(rectList.first.Y, equals(-2));
+        expect(rectList.first.height, equals(100));
+        expect(rectList.first.width, equals(200));
+        expect(rectList.first.x, equals(2));
+        expect(rectList.first.y, equals(-2));
 
         final sizeListVal = map.lookup('key21');
         expect(sizeListVal, isA<List<Size>>());
         final sizeList = sizeListVal as List<Size>;
-        expect(sizeList.first.Height, equals(1500));
-        expect(sizeList.first.Width, equals(300));
+        expect(sizeList.first.height, equals(1500));
+        expect(sizeList.first.width, equals(300));
 
         expect(map.lookup('key22'), equals(['str1', 'str2']));
       });

--- a/packages/windows_foundation/test/ireference_test.dart
+++ b/packages/windows_foundation/test/ireference_test.dart
@@ -165,15 +165,15 @@ void main() {
 
     test('IReference<Point>', () {
       final pointPtr = calloc<Point>()
-        ..ref.X = 50
-        ..ref.Y = 100;
+        ..ref.x = 50
+        ..ref.y = 100;
       final pv = PropertyValue.createPoint(pointPtr.ref);
       final ireference = IReference<Point>.fromRawPointer(
           pv.toInterface(IID_IReference_Point),
           referenceIid: IID_IReference_Point);
       expect(ireference.value, isNotNull);
-      expect(ireference.value!.X, equals(50));
-      expect(ireference.value!.Y, equals(100));
+      expect(ireference.value!.x, equals(50));
+      expect(ireference.value!.y, equals(100));
 
       ireference.release();
       pv.release();
@@ -182,19 +182,19 @@ void main() {
 
     test('IReference<Rect>', () {
       final rectPtr = calloc<Rect>()
-        ..ref.Height = 200
-        ..ref.Width = 100
-        ..ref.X = 50
-        ..ref.Y = 100;
+        ..ref.height = 200
+        ..ref.width = 100
+        ..ref.x = 50
+        ..ref.y = 100;
       final pv = PropertyValue.createRect(rectPtr.ref);
       final ireference = IReference<Rect>.fromRawPointer(
           pv.toInterface(IID_IReference_Rect),
           referenceIid: IID_IReference_Rect);
       expect(ireference.value, isNotNull);
-      expect(ireference.value!.Height, equals(200));
-      expect(ireference.value!.Width, equals(100));
-      expect(ireference.value!.X, equals(50));
-      expect(ireference.value!.Y, equals(100));
+      expect(ireference.value!.height, equals(200));
+      expect(ireference.value!.width, equals(100));
+      expect(ireference.value!.x, equals(50));
+      expect(ireference.value!.y, equals(100));
 
       ireference.release();
       pv.release();
@@ -203,15 +203,15 @@ void main() {
 
     test('IReference<Size>', () {
       final sizePtr = calloc<Size>()
-        ..ref.Height = 200
-        ..ref.Width = 100;
+        ..ref.height = 200
+        ..ref.width = 100;
       final pv = PropertyValue.createSize(sizePtr.ref);
       final ireference = IReference<Size>.fromRawPointer(
           pv.toInterface(IID_IReference_Size),
           referenceIid: IID_IReference_Size);
       expect(ireference.value, isNotNull);
-      expect(ireference.value!.Height, equals(200));
-      expect(ireference.value!.Width, equals(100));
+      expect(ireference.value!.height, equals(200));
+      expect(ireference.value!.width, equals(100));
 
       ireference.release();
       pv.release();

--- a/packages/windows_gaming/lib/src/input/structs.g.dart
+++ b/packages/windows_gaming/lib/src/input/structs.g.dart
@@ -21,28 +21,28 @@ import 'package:ffi/ffi.dart';
 /// {@category struct}
 class GamepadReading extends Struct {
   @Uint64()
-  external int Timestamp;
+  external int timestamp;
 
   @Uint32()
-  external int Buttons;
+  external int buttons;
 
   @Double()
-  external double LeftTrigger;
+  external double leftTrigger;
 
   @Double()
-  external double RightTrigger;
+  external double rightTrigger;
 
   @Double()
-  external double LeftThumbstickX;
+  external double leftThumbstickX;
 
   @Double()
-  external double LeftThumbstickY;
+  external double leftThumbstickY;
 
   @Double()
-  external double RightThumbstickX;
+  external double rightThumbstickX;
 
   @Double()
-  external double RightThumbstickY;
+  external double rightThumbstickY;
 }
 
 /// Describes the gamepad motor speed.
@@ -50,14 +50,14 @@ class GamepadReading extends Struct {
 /// {@category struct}
 class GamepadVibration extends Struct {
   @Double()
-  external double LeftMotor;
+  external double leftMotor;
 
   @Double()
-  external double RightMotor;
+  external double rightMotor;
 
   @Double()
-  external double LeftTrigger;
+  external double leftTrigger;
 
   @Double()
-  external double RightTrigger;
+  external double rightTrigger;
 }

--- a/packages/windows_media/test/collections_test.dart
+++ b/packages/windows_media/test/collections_test.dart
@@ -22,16 +22,16 @@ void main() {
       setUp(() {
         allocator = Arena();
         final pPoint = allocator<Point>()
-          ..ref.X = 3
-          ..ref.Y = -3;
+          ..ref.x = 3
+          ..ref.y = -3;
         final pRect = allocator<Rect>()
-          ..ref.Height = 100
-          ..ref.Width = 200
-          ..ref.X = 2
-          ..ref.Y = -2;
+          ..ref.height = 100
+          ..ref.width = 200
+          ..ref.x = 2
+          ..ref.y = -2;
         final pSize = allocator<Size>()
-          ..ref.Height = 1500
-          ..ref.Width = 300;
+          ..ref.height = 1500
+          ..ref.width = 300;
 
         map = MediaPropertySet()
           ..insert(Guid.parse(IID_IClosable), null)
@@ -119,22 +119,22 @@ void main() {
         final pointVal = map.lookup(Guid.parse(IID_IShellItem));
         expect(pointVal, isA<Point>());
         final point = pointVal as Point;
-        expect(point.X, equals(3));
-        expect(point.Y, equals(-3));
+        expect(point.x, equals(3));
+        expect(point.y, equals(-3));
 
         final rectVal = map.lookup(Guid.parse(IID_IShellItem2));
         expect(rectVal, isA<Rect>());
         final rect = rectVal as Rect;
-        expect(rect.Height, equals(100));
-        expect(rect.Width, equals(200));
-        expect(rect.X, equals(2));
-        expect(rect.Y, equals(-2));
+        expect(rect.height, equals(100));
+        expect(rect.width, equals(200));
+        expect(rect.x, equals(2));
+        expect(rect.y, equals(-2));
 
         final sizeVal = map.lookup(Guid.parse(IID_IShellItemArray));
         expect(sizeVal, isA<Size>());
         final size = sizeVal as Size;
-        expect(size.Height, equals(1500));
-        expect(size.Width, equals(300));
+        expect(size.height, equals(1500));
+        expect(size.width, equals(300));
 
         expect(map.lookup(Guid.parse(IID_IShellItemFilter)), equals('strVal'));
 
@@ -172,22 +172,22 @@ void main() {
         final pointListVal = map.lookup(Guid.parse(IID_IAppxManifestReader7));
         expect(pointListVal, isA<List<Point>>());
         final pointList = pointListVal as List<Point>;
-        expect(pointList.first.X, equals(3));
-        expect(pointList.first.Y, equals(-3));
+        expect(pointList.first.x, equals(3));
+        expect(pointList.first.y, equals(-3));
 
         final rectListVal = map.lookup(Guid.parse(IID_IAppxManifestProperties));
         expect(rectListVal, isA<List<Rect>>());
         final rectList = rectListVal as List<Rect>;
-        expect(rectList.first.Height, equals(100));
-        expect(rectList.first.Width, equals(200));
-        expect(rectList.first.X, equals(2));
-        expect(rectList.first.Y, equals(-2));
+        expect(rectList.first.height, equals(100));
+        expect(rectList.first.width, equals(200));
+        expect(rectList.first.x, equals(2));
+        expect(rectList.first.y, equals(-2));
 
         final sizeListVal = map.lookup(Guid.parse(IID_IAppxManifestPackageId));
         expect(sizeListVal, isA<List<Size>>());
         final sizeList = sizeListVal as List<Size>;
-        expect(sizeList.first.Height, equals(1500));
-        expect(sizeList.first.Width, equals(300));
+        expect(sizeList.first.height, equals(1500));
+        expect(sizeList.first.width, equals(300));
 
         expect(map.lookup(Guid.parse(IID_IAppxFile)), equals(['str1', 'str2']));
       });

--- a/packages/windows_ui/lib/src/structs.g.dart
+++ b/packages/windows_ui/lib/src/structs.g.dart
@@ -21,14 +21,14 @@ import 'package:ffi/ffi.dart';
 /// {@category struct}
 class Color extends Struct {
   @Uint8()
-  external int A;
+  external int a;
 
   @Uint8()
-  external int R;
+  external int r;
 
   @Uint8()
-  external int G;
+  external int g;
 
   @Uint8()
-  external int B;
+  external int b;
 }

--- a/packages/winrtgen/lib/src/projections/winrt_struct.dart
+++ b/packages/winrtgen/lib/src/projections/winrt_struct.dart
@@ -4,18 +4,19 @@
 
 import 'package:winmd/winmd.dart';
 
+import '../extensions.dart';
 import '../utils.dart';
 import 'type.dart';
 
-/// A field.
+/// A struct field.
 ///
 /// Fields are a tuple of a type and a name.
 class StructFieldProjection {
+  StructFieldProjection(this.field)
+      : fieldName = safeIdentifierForString(field.name.toCamelCase());
+
   final Field field;
   final String fieldName;
-
-  StructFieldProjection(this.field)
-      : fieldName = safeIdentifierForString(field.name);
 
   @override
   String toString() {
@@ -29,13 +30,13 @@ class StructFieldProjection {
   }
 }
 
-/// Represents a Dart projection of a Struct typedef.
+/// Represents a Dart projection of a WinRT Struct typedef.
 class WinRTStructProjection {
+  WinRTStructProjection(this.typeDef, this.structName, {this.comment = ''});
+
   final TypeDef typeDef;
   final String structName;
   final String comment;
-
-  WinRTStructProjection(this.typeDef, this.structName, {this.comment = ''});
 
   String get category => 'struct';
 
@@ -49,13 +50,15 @@ class WinRTStructProjection {
     return docComment;
   }
 
+  String get classDeclaration => 'class $structName extends Struct {';
+
   List<StructFieldProjection> get fields =>
       typeDef.fields.map(StructFieldProjection.new).toList();
 
   @override
   String toString() => '''
 $classPreamble
-class $structName extends Struct {
+$classDeclaration
   ${fields.join('\n')}
 }
 ''';


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

Converts struct fields to `camelCase`.

## Related Issue

None

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
