### PR TITLE
Move `uniquelyNameMethod` to utils.dart

### DIFF
--- a/packages/winrtgen/lib/src/projections/winrt_method.dart
+++ b/packages/winrtgen/lib/src/projections/winrt_method.dart
@@ -98,47 +98,6 @@ abstract class WinRTMethodProjection {
     }
   }
 
-  /// Uniquely name the method.
-  ///
-  /// Dart doesn't allow overloaded methods, so we have to rename methods that
-  /// are duplicated.
-  static String uniquelyNameMethod(Method method) {
-    // Is it a WinRT method overloaded with a name provided by the metadata?
-    final overloadName = method
-        .attributeAsString('Windows.Foundation.Metadata.OverloadAttribute');
-    if (overloadName.isNotEmpty) return overloadName;
-
-    // If not, we check whether multiple methods exist with the same name. We
-    // also need to check up the interface chain, since otherwise overloaded
-    // methods may be missed. For example, IDWriteFactory2 contains methods that
-    // overload those in IDWriteFactory1.
-    final overloads =
-        method.parent.methods.where((m) => m.name == method.name).toList();
-    var interfaceTypeDef = method.parent;
-    // perf optimization to save work on the most common case of IUnknown
-    while (interfaceTypeDef.interfaces.isNotEmpty &&
-        !(interfaceTypeDef.interfaces.first.name ==
-            'Windows.Win32.System.Com.IUnknown')) {
-      interfaceTypeDef = interfaceTypeDef.interfaces.first;
-      overloads
-          .addAll(interfaceTypeDef.methods.where((m) => m.name == method.name));
-    }
-
-    // If so, and there is more than one entry with the same name, add a suffix
-    // to all but the first.
-    if (overloads.length > 1) {
-      final reversedOverloads = overloads.reversed.toList();
-      final overloadIndex =
-          reversedOverloads.indexWhere((m) => m.token == method.token);
-      if (overloadIndex > 0) {
-        return '${safeIdentifierForString(method.name)}_$overloadIndex';
-      }
-    }
-
-    // Otherwise the original name is fine.
-    return method.name;
-  }
-
   /// The method name without uppercased first letter.
   ///
   /// Windows Runtime methods and properties are typically named in TitleCase,


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

Moves `uniquelyNameMethod` to utils.dart.

## Related Issue

None

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
