### PR TITLE
Refactor projection of `IReference<T>` types

### DIFF
--- a/packages/windows_devices/lib/src/geolocation/igeocoordinate.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeocoordinate.dart
@@ -94,7 +94,7 @@ class IGeocoordinate extends IInspectable {
       return null;
     }
 
-    final reference = IReference<double>.fromRawPointer(retValuePtr,
+    final reference = IReference<double?>.fromRawPointer(retValuePtr,
         referenceIid: '{2f2d6c29-5473-5f3e-92e7-96572bb990e2}');
     final value = reference.value;
     reference.release();
@@ -147,7 +147,7 @@ class IGeocoordinate extends IInspectable {
       return null;
     }
 
-    final reference = IReference<double>.fromRawPointer(retValuePtr,
+    final reference = IReference<double?>.fromRawPointer(retValuePtr,
         referenceIid: '{2f2d6c29-5473-5f3e-92e7-96572bb990e2}');
     final value = reference.value;
     reference.release();
@@ -178,7 +178,7 @@ class IGeocoordinate extends IInspectable {
       return null;
     }
 
-    final reference = IReference<double>.fromRawPointer(retValuePtr,
+    final reference = IReference<double?>.fromRawPointer(retValuePtr,
         referenceIid: '{2f2d6c29-5473-5f3e-92e7-96572bb990e2}');
     final value = reference.value;
     reference.release();
@@ -209,7 +209,7 @@ class IGeocoordinate extends IInspectable {
       return null;
     }
 
-    final reference = IReference<double>.fromRawPointer(retValuePtr,
+    final reference = IReference<double?>.fromRawPointer(retValuePtr,
         referenceIid: '{2f2d6c29-5473-5f3e-92e7-96572bb990e2}');
     final value = reference.value;
     reference.release();

--- a/packages/windows_devices/lib/src/geolocation/igeocoordinatesatellitedata.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeocoordinatesatellitedata.dart
@@ -52,7 +52,7 @@ class IGeocoordinateSatelliteData extends IInspectable {
       return null;
     }
 
-    final reference = IReference<double>.fromRawPointer(retValuePtr,
+    final reference = IReference<double?>.fromRawPointer(retValuePtr,
         referenceIid: '{2f2d6c29-5473-5f3e-92e7-96572bb990e2}');
     final value = reference.value;
     reference.release();
@@ -83,7 +83,7 @@ class IGeocoordinateSatelliteData extends IInspectable {
       return null;
     }
 
-    final reference = IReference<double>.fromRawPointer(retValuePtr,
+    final reference = IReference<double?>.fromRawPointer(retValuePtr,
         referenceIid: '{2f2d6c29-5473-5f3e-92e7-96572bb990e2}');
     final value = reference.value;
     reference.release();
@@ -114,7 +114,7 @@ class IGeocoordinateSatelliteData extends IInspectable {
       return null;
     }
 
-    final reference = IReference<double>.fromRawPointer(retValuePtr,
+    final reference = IReference<double?>.fromRawPointer(retValuePtr,
         referenceIid: '{2f2d6c29-5473-5f3e-92e7-96572bb990e2}');
     final value = reference.value;
     reference.release();

--- a/packages/windows_devices/lib/src/geolocation/igeocoordinatesatellitedata2.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeocoordinatesatellitedata2.dart
@@ -52,7 +52,7 @@ class IGeocoordinateSatelliteData2 extends IInspectable {
       return null;
     }
 
-    final reference = IReference<double>.fromRawPointer(retValuePtr,
+    final reference = IReference<double?>.fromRawPointer(retValuePtr,
         referenceIid: '{2f2d6c29-5473-5f3e-92e7-96572bb990e2}');
     final value = reference.value;
     reference.release();
@@ -83,7 +83,7 @@ class IGeocoordinateSatelliteData2 extends IInspectable {
       return null;
     }
 
-    final reference = IReference<double>.fromRawPointer(retValuePtr,
+    final reference = IReference<double?>.fromRawPointer(retValuePtr,
         referenceIid: '{2f2d6c29-5473-5f3e-92e7-96572bb990e2}');
     final value = reference.value;
     reference.release();

--- a/packages/windows_devices/lib/src/geolocation/igeocoordinatewithpositionsourcetimestamp.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeocoordinatewithpositionsourcetimestamp.dart
@@ -53,7 +53,7 @@ class IGeocoordinateWithPositionSourceTimestamp extends IInspectable {
       return null;
     }
 
-    final reference = IReference<DateTime>.fromRawPointer(retValuePtr,
+    final reference = IReference<DateTime?>.fromRawPointer(retValuePtr,
         referenceIid: '{5541d8a7-497c-5aa4-86fc-7713adbf2a2c}');
     final value = reference.value;
     reference.release();

--- a/packages/windows_devices/lib/src/geolocation/igeolocatorstatics2.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeolocatorstatics2.dart
@@ -90,7 +90,7 @@ class IGeolocatorStatics2 extends IInspectable {
       return null;
     }
 
-    final reference = IReference<BasicGeoposition>.fromRawPointer(retValuePtr,
+    final reference = IReference<BasicGeoposition?>.fromRawPointer(retValuePtr,
         referenceIid: '{e4d5dda6-f57c-57cc-b67f-2939a901dabe}');
     final value = reference.value;
     reference.release();

--- a/packages/windows_devices/lib/src/geolocation/igeolocatorwithscalaraccuracy.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeolocatorwithscalaraccuracy.dart
@@ -58,7 +58,7 @@ class IGeolocatorWithScalarAccuracy extends IInspectable
       return null;
     }
 
-    final reference = IReference<int>.fromRawPointer(retValuePtr,
+    final reference = IReference<int?>.fromRawPointer(retValuePtr,
         referenceIid: '{513ef3af-e784-5325-a91e-97c2b8111cf3}');
     final value = reference.value;
     reference.release();

--- a/packages/windows_devices/lib/src/power/ibatteryreport.dart
+++ b/packages/windows_devices/lib/src/power/ibatteryreport.dart
@@ -51,7 +51,7 @@ class IBatteryReport extends IInspectable {
       return null;
     }
 
-    final reference = IReference<int>.fromRawPointer(retValuePtr,
+    final reference = IReference<int?>.fromRawPointer(retValuePtr,
         referenceIid: '{548cefbd-bc8a-5fa0-8df2-957440fc8bf4}');
     final value = reference.value;
     reference.release();
@@ -82,7 +82,7 @@ class IBatteryReport extends IInspectable {
       return null;
     }
 
-    final reference = IReference<int>.fromRawPointer(retValuePtr,
+    final reference = IReference<int?>.fromRawPointer(retValuePtr,
         referenceIid: '{548cefbd-bc8a-5fa0-8df2-957440fc8bf4}');
     final value = reference.value;
     reference.release();
@@ -113,7 +113,7 @@ class IBatteryReport extends IInspectable {
       return null;
     }
 
-    final reference = IReference<int>.fromRawPointer(retValuePtr,
+    final reference = IReference<int?>.fromRawPointer(retValuePtr,
         referenceIid: '{548cefbd-bc8a-5fa0-8df2-957440fc8bf4}');
     final value = reference.value;
     reference.release();
@@ -144,7 +144,7 @@ class IBatteryReport extends IInspectable {
       return null;
     }
 
-    final reference = IReference<int>.fromRawPointer(retValuePtr,
+    final reference = IReference<int?>.fromRawPointer(retValuePtr,
         referenceIid: '{548cefbd-bc8a-5fa0-8df2-957440fc8bf4}');
     final value = reference.value;
     reference.release();

--- a/packages/windows_foundation/lib/src/helpers.dart
+++ b/packages/windows_foundation/lib/src/helpers.dart
@@ -152,14 +152,6 @@ bool isSimilarType<S, T>() => isSameType<S, T>() || isSameType<S, T?>();
 /// ```
 bool isSubtype<S, T>() => <S>[] is List<T> || <S>[] is List<T?>;
 
-/// Determines whether [T] is a subtype of `WinRTEnum`.
-///
-/// ```dart
-/// isSubtypeOfWinRTEnum<AsyncStatus>(); // true
-/// isSubtypeOfWinRTEnum<FileAttributes>(); // true
-/// ```
-bool isSubtypeOfWinRTEnum<T>() => isSubtype<T, WinRTEnum>();
-
 /// Determines whether [T] is a subtype of `IInspectable`.
 ///
 /// ```dart
@@ -167,6 +159,22 @@ bool isSubtypeOfWinRTEnum<T>() => isSubtype<T, WinRTEnum>();
 /// isSubtypeOfInspectable<INetwork>(); // false
 /// ```
 bool isSubtypeOfInspectable<T>() => isSubtype<T, IInspectable>();
+
+/// Determines whether [T] is a subtype of [Struct].
+///
+/// ```dart
+/// isSubtypeOfStruct<Point>(); // true
+/// isSubtypeOfStruct<GUID>(); // true
+/// ```
+bool isSubtypeOfStruct<T>() => isSubtype<T, Struct>();
+
+/// Determines whether [T] is a subtype of [WinRTEnum].
+///
+/// ```dart
+/// isSubtypeOfWinRTEnum<AsyncStatus>(); // true
+/// isSubtypeOfWinRTEnum<FileAttributes>(); // true
+/// ```
+bool isSubtypeOfWinRTEnum<T>() => isSubtype<T, WinRTEnum>();
 
 /// Represents the trust level of an activatable class.
 ///

--- a/packages/windows_foundation/test/ireference_test.dart
+++ b/packages/windows_foundation/test/ireference_test.dart
@@ -16,9 +16,9 @@ import 'package:windows_foundation/windows_foundation.dart';
 
 void main() {
   if (isWindowsRuntimeAvailable()) {
-    test('IReference<bool>', () {
+    test('IReference<bool?>', () {
       final pv = PropertyValue.createBoolean(true);
-      final ireference = IReference<bool>.fromRawPointer(
+      final ireference = IReference<bool?>.fromRawPointer(
           pv.toInterface(IID_IReference_Boolean),
           referenceIid: IID_IReference_Boolean);
       expect(ireference.value, isNotNull);
@@ -28,10 +28,10 @@ void main() {
       pv.release();
     });
 
-    test('IReference<DateTime>', () {
+    test('IReference<DateTime?>', () {
       final dateTime = DateTime(2022, 8, 28, 17);
       final pv = PropertyValue.createDateTime(dateTime);
-      final ireference = IReference<DateTime>.fromRawPointer(
+      final ireference = IReference<DateTime?>.fromRawPointer(
           pv.toInterface(IID_IReference_DateTime),
           referenceIid: IID_IReference_DateTime);
       expect(ireference.value, isNotNull);
@@ -42,9 +42,9 @@ void main() {
       pv.release();
     });
 
-    test('IReference<double> (Double)', () {
+    test('IReference<double?> (Double)', () {
       final pv = PropertyValue.createDouble(3.0);
-      final ireference = IReference<double>.fromRawPointer(
+      final ireference = IReference<double?>.fromRawPointer(
           pv.toInterface(IID_IReference_Double),
           referenceIid: IID_IReference_Double);
       expect(ireference.value, isNotNull);
@@ -54,9 +54,9 @@ void main() {
       pv.release();
     });
 
-    test('IReference<double> (Float)', () {
+    test('IReference<double?> (Float)', () {
       final pv = PropertyValue.createSingle(3.0);
-      final ireference = IReference<double>.fromRawPointer(
+      final ireference = IReference<double?>.fromRawPointer(
           pv.toInterface(IID_IReference_Float),
           referenceIid: IID_IReference_Float);
       expect(ireference.value, isNotNull);
@@ -66,10 +66,10 @@ void main() {
       pv.release();
     });
 
-    test('IReference<Duration>', () {
+    test('IReference<Duration?>', () {
       const duration = Duration(seconds: 30);
       final pv = PropertyValue.createTimeSpan(duration);
-      final ireference = IReference<Duration>.fromRawPointer(
+      final ireference = IReference<Duration?>.fromRawPointer(
           pv.toInterface(IID_IReference_TimeSpan),
           referenceIid: IID_IReference_TimeSpan);
       expect(ireference.value, isNotNull);
@@ -79,9 +79,9 @@ void main() {
       pv.release();
     });
 
-    test('IReference<Guid>', () {
+    test('IReference<Guid?>', () {
       final pv = PropertyValue.createGuid(Guid.parse(IID_IAsyncInfo));
-      final ireference = IReference<Guid>.fromRawPointer(
+      final ireference = IReference<Guid?>.fromRawPointer(
           pv.toInterface(IID_IReference_Guid),
           referenceIid: IID_IReference_Guid);
       expect(ireference.value, isNotNull);
@@ -91,9 +91,9 @@ void main() {
       pv.release();
     });
 
-    test('IReference<int> (Int16)', () {
+    test('IReference<int?> (Int16)', () {
       final pv = PropertyValue.createInt16(16);
-      final ireference = IReference<int>.fromRawPointer(
+      final ireference = IReference<int?>.fromRawPointer(
           pv.toInterface(IID_IReference_Int16),
           referenceIid: IID_IReference_Int16);
       expect(ireference.value, isNotNull);
@@ -103,9 +103,9 @@ void main() {
       pv.release();
     });
 
-    test('IReference<int> (Int32)', () {
+    test('IReference<int?> (Int32)', () {
       final pv = PropertyValue.createInt32(32);
-      final ireference = IReference<int>.fromRawPointer(
+      final ireference = IReference<int?>.fromRawPointer(
           pv.toInterface(IID_IReference_Int32),
           referenceIid: IID_IReference_Int32);
       expect(ireference.value, isNotNull);
@@ -115,9 +115,9 @@ void main() {
       pv.release();
     });
 
-    test('IReference<int> (Int64)', () {
+    test('IReference<int?> (Int64)', () {
       final pv = PropertyValue.createInt64(64);
-      final ireference = IReference<int>.fromRawPointer(
+      final ireference = IReference<int?>.fromRawPointer(
           pv.toInterface(IID_IReference_Int64),
           referenceIid: IID_IReference_Int64);
       expect(ireference.value, isNotNull);
@@ -127,9 +127,9 @@ void main() {
       pv.release();
     });
 
-    test('IReference<int> (Uint8)', () {
+    test('IReference<int?> (Uint8)', () {
       final pv = PropertyValue.createUInt8(8);
-      final ireference = IReference<int>.fromRawPointer(
+      final ireference = IReference<int?>.fromRawPointer(
           pv.toInterface(IID_IReference_Uint8),
           referenceIid: IID_IReference_Uint8);
       expect(ireference.value, isNotNull);
@@ -139,9 +139,9 @@ void main() {
       pv.release();
     });
 
-    test('IReference<int> (Uint32)', () {
+    test('IReference<int?> (Uint32)', () {
       final pv = PropertyValue.createUInt32(32);
-      final ireference = IReference<int>.fromRawPointer(
+      final ireference = IReference<int?>.fromRawPointer(
           pv.toInterface(IID_IReference_Uint32),
           referenceIid: IID_IReference_Uint32);
       expect(ireference.value, isNotNull);
@@ -151,9 +151,9 @@ void main() {
       pv.release();
     });
 
-    test('IReference<int> (Uint64)', () {
+    test('IReference<int?> (Uint64)', () {
       final pv = PropertyValue.createUInt64(64);
-      final ireference = IReference<int>.fromRawPointer(
+      final ireference = IReference<int?>.fromRawPointer(
           pv.toInterface(IID_IReference_Uint64),
           referenceIid: IID_IReference_Uint64);
       expect(ireference.value, isNotNull);
@@ -163,12 +163,12 @@ void main() {
       pv.release();
     });
 
-    test('IReference<Point>', () {
+    test('IReference<Point?>', () {
       final pointPtr = calloc<Point>()
         ..ref.x = 50
         ..ref.y = 100;
       final pv = PropertyValue.createPoint(pointPtr.ref);
-      final ireference = IReference<Point>.fromRawPointer(
+      final ireference = IReference<Point?>.fromRawPointer(
           pv.toInterface(IID_IReference_Point),
           referenceIid: IID_IReference_Point);
       expect(ireference.value, isNotNull);
@@ -180,14 +180,14 @@ void main() {
       free(pointPtr);
     });
 
-    test('IReference<Rect>', () {
+    test('IReference<Rect?>', () {
       final rectPtr = calloc<Rect>()
         ..ref.height = 200
         ..ref.width = 100
         ..ref.x = 50
         ..ref.y = 100;
       final pv = PropertyValue.createRect(rectPtr.ref);
-      final ireference = IReference<Rect>.fromRawPointer(
+      final ireference = IReference<Rect?>.fromRawPointer(
           pv.toInterface(IID_IReference_Rect),
           referenceIid: IID_IReference_Rect);
       expect(ireference.value, isNotNull);
@@ -201,12 +201,12 @@ void main() {
       free(rectPtr);
     });
 
-    test('IReference<Size>', () {
+    test('IReference<Size?>', () {
       final sizePtr = calloc<Size>()
         ..ref.height = 200
         ..ref.width = 100;
       final pv = PropertyValue.createSize(sizePtr.ref);
-      final ireference = IReference<Size>.fromRawPointer(
+      final ireference = IReference<Size?>.fromRawPointer(
           pv.toInterface(IID_IReference_Size),
           referenceIid: IID_IReference_Size);
       expect(ireference.value, isNotNull);

--- a/packages/windows_networking/lib/src/connectivity/iipinformation.dart
+++ b/packages/windows_networking/lib/src/connectivity/iipinformation.dart
@@ -78,7 +78,7 @@ class IIPInformation extends IInspectable {
       return null;
     }
 
-    final reference = IReference<int>.fromRawPointer(retValuePtr,
+    final reference = IReference<int?>.fromRawPointer(retValuePtr,
         referenceIid: '{e5198cc8-2873-55f5-b0a1-84ff9e4aad62}');
     final value = reference.value;
     reference.release();

--- a/packages/winrtgen/bin/generate.dart
+++ b/packages/winrtgen/bin/generate.dart
@@ -148,8 +148,10 @@ void generatePackageExports() {
     final exports = <String>{};
 
     for (final file in files) {
-      // Skip internally used files from the windows_foundation package
-      if (file.path.contains(r'internal\')) continue;
+      if (packageName == 'windows_foundation') {
+        // Skip internally used files
+        if (file.path.contains(r'internal\')) continue;
+      }
 
       final fileName = file.uri.pathSegments.last; // e.g. calendar.dart
 

--- a/packages/winrtgen/lib/src/extensions/type_identifier_helpers.dart
+++ b/packages/winrtgen/lib/src/extensions/type_identifier_helpers.dart
@@ -88,8 +88,7 @@ String _parseGenericTypeIdentifierName(TypeIdentifier typeIdentifier) {
     return '$parentTypeName<$firstArg, $secondArg$questionMark>';
   }
 
-  final isAsyncOperation = parentTypeName == 'IAsyncOperation';
-  if (isAsyncOperation) {
+  if (parentTypeName == 'IAsyncOperation') {
     final typeArg = typeIdentifier.typeArg!.shortName;
     final typeProjection = TypeProjection(typeIdentifier.typeArg!);
     final typeArgIsNullable =
@@ -101,6 +100,12 @@ String _parseGenericTypeIdentifierName(TypeIdentifier typeIdentifier) {
             !typeProjection.isValueType;
     final questionMark = typeArgIsNullable ? '?' : '';
     return 'IAsyncOperation<$typeArg$questionMark>';
+  }
+
+  if (parentTypeName == 'IReference') {
+    final typeArg = typeIdentifier.typeArg!.shortName;
+    // Mark typeArg as nullable as all IReference types are nullable.
+    return 'IReference<$typeArg?>';
   }
 
   return '$parentTypeName<${typeIdentifier.typeArg!.shortName}>';

--- a/packages/winrtgen/lib/src/projections/types/reference.dart
+++ b/packages/winrtgen/lib/src/projections/types/reference.dart
@@ -15,7 +15,7 @@ import '../type.dart';
 
 mixin _ReferenceProjection on MethodProjection {
   /// The type argument of `IReference`, as represented in the [returnType]'s
-  /// [TypeIdentifier] (e.g. `DateTime`, `int`, `String`).
+  /// [TypeIdentifier] (e.g. `DateTime?`, `int?`, `WebErrorStatus?`).
   String get referenceTypeArg => typeArguments(returnType.typeIdentifier.name);
 
   /// The type argument of `IReference`, as represented in the [TypeIdentifier]
@@ -84,7 +84,7 @@ mixin _ReferenceProjection on MethodProjection {
 ''';
 }
 
-/// Method projection for methods that return an `IReference<T>` (exposed as
+/// Method projection for methods that return an `IReference<T?>` (exposed as
 /// `T?`).
 class ReferenceMethodProjection extends MethodProjection
     with _ReferenceProjection {
@@ -92,7 +92,7 @@ class ReferenceMethodProjection extends MethodProjection
 
   @override
   String get methodProjection => '''
-  $referenceTypeArg? $camelCasedName($methodParams) {
+  $referenceTypeArg $camelCasedName($methodParams) {
     final retValuePtr = calloc<COMObject>();
     $parametersPreamble
 
@@ -112,14 +112,14 @@ class ReferenceMethodProjection extends MethodProjection
 ''';
 }
 
-/// Getter projection for `IReference<T>` (exposed as `T?`) getters.
+/// Getter projection for `IReference<T?>` (exposed as `T?`) getters.
 class ReferenceGetterProjection extends GetterProjection
     with _ReferenceProjection {
   ReferenceGetterProjection(super.method, super.vtableOffset);
 
   @override
   String get methodProjection => '''
-  $referenceTypeArg? get $camelCasedName {
+  $referenceTypeArg get $camelCasedName {
     final retValuePtr = calloc<COMObject>();
 
     ${ffiCall(freeRetValOnFailure: true)}
@@ -136,20 +136,20 @@ class ReferenceGetterProjection extends GetterProjection
 ''';
 }
 
-/// Setter projection for `IReference<T>` (exposed as `T?`) setters.
+/// Setter projection for `IReference<T?>` (exposed as `T?`) setters.
 class ReferenceSetterProjection extends SetterProjection
     with _ReferenceProjection {
   ReferenceSetterProjection(super.method, super.vtableOffset);
 
   @override
   String get methodProjection => '''
-  set $camelCasedName($referenceTypeArgFromParameter? value) {
+  set $camelCasedName($referenceTypeArgFromParameter value) {
     ${ffiCall(params: 'value == null ? nullptr : $boxValueMethodCall.ref.lpVtbl')}
   }
 ''';
 }
 
-/// Parameter projection for `IReference<T>` (exposed as `T?`) parameters.
+/// Parameter projection for `IReference<T?>` (exposed as `T?`) parameters.
 class ReferenceParameterProjection extends ParameterProjection {
   ReferenceParameterProjection(super.parameter);
 

--- a/packages/winrtgen/test/extensions/type_identifier_helpers_test.dart
+++ b/packages/winrtgen/test/extensions/type_identifier_helpers_test.dart
@@ -270,7 +270,7 @@ void main() {
               .returnType
               .typeIdentifier
               .shortName,
-          equals('IReference<int>'));
+          equals('IReference<int?>'));
     });
 
     test('4', () {
@@ -282,7 +282,7 @@ void main() {
               .returnType
               .typeIdentifier
               .shortName,
-          equals('IReference<BasicGeoposition>'));
+          equals('IReference<BasicGeoposition?>'));
     });
 
     test('5', () {

--- a/packages/winrtgen/test/projections/getter_test.dart
+++ b/packages/winrtgen/test/projections/getter_test.dart
@@ -199,7 +199,7 @@ void main() {
           contains("iterableIid: '{fe2f3d47-5d47-5499-8374-430c7cda0204}'"));
     });
 
-    test('projects IReference<DateTime>', () {
+    test('projects IReference<DateTime?>', () {
       final projection = GetterProjection.fromTypeAndMethodName(
           'Windows.UI.Notifications.IToastNotification', 'get_ExpirationTime');
       expect(projection, isA<ReferenceGetterProjection>());

--- a/packages/winrtgen/test/projections/method_test.dart
+++ b/packages/winrtgen/test/projections/method_test.dart
@@ -184,7 +184,7 @@ void main() {
           projection.shortDeclaration, equals('Map<String, String> getView()'));
     });
 
-    test('projects IReference<int>', () {
+    test('projects IReference<int?>', () {
       final projection = MethodProjection.fromTypeAndMethodName(
           'Windows.Networking.Connectivity.ConnectionProfile', 'GetSignalBars');
       expect(projection, isA<ReferenceMethodProjection>());

--- a/packages/winrtgen/test/projections/setter_test.dart
+++ b/packages/winrtgen/test/projections/setter_test.dart
@@ -166,7 +166,7 @@ void main() {
           equals('set targetFile(IStorageFile? value)'));
     });
 
-    test('projects IReference<BluetoothLEAdvertisementFlags>', () {
+    test('projects IReference<BluetoothLEAdvertisementFlags?>', () {
       final projection = SetterProjection.fromTypeAndMethodName(
           'Windows.Devices.Bluetooth.Advertisement.IBluetoothLEAdvertisement',
           'put_Flags');


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

- Exposes `IReference` type arguments as `nullable` (e.g. `IReference<int?>` instead of `IReference<int>`)
- Converts `IReference<T>` class to `abstract` class
- Adds private subclasses for `IReference`'s supported type arguments (e.g. `_IReferenceBool` class for `IReference<bool?>` types)

## Related Issue

None

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
