### PR TITLE
Optimize null pointer checks

### DIFF
--- a/packages/windows_data/lib/src/json/ijsonarray.dart
+++ b/packages/windows_data/lib/src/json/ijsonarray.dart
@@ -51,7 +51,7 @@ class IJsonArray extends IInspectable implements IJsonValue {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -78,7 +78,7 @@ class IJsonArray extends IInspectable implements IJsonValue {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_data/lib/src/json/ijsonarraystatics.dart
+++ b/packages/windows_data/lib/src/json/ijsonarraystatics.dart
@@ -52,7 +52,7 @@ class IJsonArrayStatics extends IInspectable {
 
     WindowsDeleteString(inputHString);
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_data/lib/src/json/ijsonobject.dart
+++ b/packages/windows_data/lib/src/json/ijsonobject.dart
@@ -55,7 +55,7 @@ class IJsonObject extends IInspectable implements IJsonValue {
 
     WindowsDeleteString(nameHString);
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -107,7 +107,7 @@ class IJsonObject extends IInspectable implements IJsonValue {
 
     WindowsDeleteString(nameHString);
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -137,7 +137,7 @@ class IJsonObject extends IInspectable implements IJsonValue {
 
     WindowsDeleteString(nameHString);
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_data/lib/src/json/ijsonobjectstatics.dart
+++ b/packages/windows_data/lib/src/json/ijsonobjectstatics.dart
@@ -52,7 +52,7 @@ class IJsonObjectStatics extends IInspectable {
 
     WindowsDeleteString(inputHString);
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_data/lib/src/json/ijsonobjectwithdefaultvalues.dart
+++ b/packages/windows_data/lib/src/json/ijsonobjectwithdefaultvalues.dart
@@ -65,7 +65,7 @@ class IJsonObjectWithDefaultValues extends IInspectable
 
     WindowsDeleteString(nameHString);
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -101,7 +101,7 @@ class IJsonObjectWithDefaultValues extends IInspectable
 
     WindowsDeleteString(nameHString);
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -167,7 +167,7 @@ class IJsonObjectWithDefaultValues extends IInspectable
 
     WindowsDeleteString(nameHString);
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_data/lib/src/json/ijsonvalue.dart
+++ b/packages/windows_data/lib/src/json/ijsonvalue.dart
@@ -161,7 +161,7 @@ class IJsonValue extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -187,7 +187,7 @@ class IJsonValue extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_data/lib/src/json/ijsonvaluestatics.dart
+++ b/packages/windows_data/lib/src/json/ijsonvaluestatics.dart
@@ -52,7 +52,7 @@ class IJsonValueStatics extends IInspectable {
 
     WindowsDeleteString(inputHString);
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -108,7 +108,7 @@ class IJsonValueStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -136,7 +136,7 @@ class IJsonValueStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -166,7 +166,7 @@ class IJsonValueStatics extends IInspectable {
 
     WindowsDeleteString(inputHString);
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_data/lib/src/json/ijsonvaluestatics2.dart
+++ b/packages/windows_data/lib/src/json/ijsonvaluestatics2.dart
@@ -48,7 +48,7 @@ class IJsonValueStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/geolocation/igeocoordinate.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeocoordinate.dart
@@ -89,7 +89,7 @@ class IGeocoordinate extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -142,7 +142,7 @@ class IGeocoordinate extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -173,7 +173,7 @@ class IGeocoordinate extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -204,7 +204,7 @@ class IGeocoordinate extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/geolocation/igeocoordinatesatellitedata.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeocoordinatesatellitedata.dart
@@ -47,7 +47,7 @@ class IGeocoordinateSatelliteData extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -78,7 +78,7 @@ class IGeocoordinateSatelliteData extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -109,7 +109,7 @@ class IGeocoordinateSatelliteData extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/geolocation/igeocoordinatesatellitedata2.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeocoordinatesatellitedata2.dart
@@ -47,7 +47,7 @@ class IGeocoordinateSatelliteData2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -78,7 +78,7 @@ class IGeocoordinateSatelliteData2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/geolocation/igeocoordinatewithpoint.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeocoordinatewithpoint.dart
@@ -48,7 +48,7 @@ class IGeocoordinateWithPoint extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/geolocation/igeocoordinatewithpositiondata.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeocoordinatewithpositiondata.dart
@@ -74,7 +74,7 @@ class IGeocoordinateWithPositionData extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/geolocation/igeocoordinatewithpositionsourcetimestamp.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeocoordinatewithpositionsourcetimestamp.dart
@@ -48,7 +48,7 @@ class IGeocoordinateWithPositionSourceTimestamp extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/geolocation/igeolocatorstatics2.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeolocatorstatics2.dart
@@ -85,7 +85,7 @@ class IGeolocatorStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/geolocation/igeolocatorwithscalaraccuracy.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeolocatorwithscalaraccuracy.dart
@@ -53,7 +53,7 @@ class IGeolocatorWithScalarAccuracy extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/geolocation/igeoposition.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeoposition.dart
@@ -48,7 +48,7 @@ class IGeoposition extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -74,7 +74,7 @@ class IGeoposition extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/geolocation/igeoposition2.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeoposition2.dart
@@ -50,7 +50,7 @@ class IGeoposition2 extends IInspectable implements IGeoposition {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/power/ibatteryreport.dart
+++ b/packages/windows_devices/lib/src/power/ibatteryreport.dart
@@ -46,7 +46,7 @@ class IBatteryReport extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -77,7 +77,7 @@ class IBatteryReport extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -108,7 +108,7 @@ class IBatteryReport extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -139,7 +139,7 @@ class IBatteryReport extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_foundation/lib/src/collections/ikeyvaluepair.dart
+++ b/packages/windows_foundation/lib/src/collections/ikeyvaluepair.dart
@@ -369,7 +369,7 @@ Pointer<COMObject>? _valueCOMObject(Pointer<COMObject> ptr) {
     throw WindowsException(hr);
   }
 
-  if (retValuePtr.ref.lpVtbl == nullptr) {
+  if (retValuePtr.ref.isNull) {
     free(retValuePtr);
     return null;
   }
@@ -395,7 +395,7 @@ Object? _valueObject(Pointer<COMObject> ptr) {
     throw WindowsException(hr);
   }
 
-  if (retValuePtr.ref.lpVtbl == nullptr) {
+  if (retValuePtr.ref.isNull) {
     free(retValuePtr);
     return null;
   }

--- a/packages/windows_foundation/lib/src/collections/imap.dart
+++ b/packages/windows_foundation/lib/src/collections/imap.dart
@@ -247,7 +247,7 @@ class _IMapEnumInspectable<K, V> extends IMap<K, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -481,7 +481,7 @@ class _IMapGuidObject extends IMap<Guid, Object?> {
 
     free(nativeGuidPtr);
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -956,7 +956,7 @@ class _IMapStringObject extends IMap<String, Object?> {
         throw WindowsException(hr);
       }
 
-      if (retValuePtr.ref.lpVtbl == nullptr) {
+      if (retValuePtr.ref.isNull) {
         free(retValuePtr);
         return null;
       }

--- a/packages/windows_foundation/lib/src/collections/imapview.dart
+++ b/packages/windows_foundation/lib/src/collections/imapview.dart
@@ -193,7 +193,7 @@ class _IMapViewEnumInspectable<K, V> extends IMapView<K, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -269,7 +269,7 @@ class _IMapViewGuidInspectable<V> extends IMapView<Guid, V> {
 
     free(nativeGuidPtr);
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -321,7 +321,7 @@ class _IMapViewGuidObject extends IMapView<Guid, Object?> {
 
     free(nativeGuidPtr);
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -376,7 +376,7 @@ class _IMapViewIntInspectable<V> extends IMapView<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -505,7 +505,7 @@ class _IMapViewStringInspectable<V> extends IMapView<String, V> {
         throw WindowsException(hr);
       }
 
-      if (retValuePtr.ref.lpVtbl == nullptr) {
+      if (retValuePtr.ref.isNull) {
         free(retValuePtr);
         return null as V;
       }
@@ -559,7 +559,7 @@ class _IMapViewStringObject extends IMapView<String, Object?> {
         throw WindowsException(hr);
       }
 
-      if (retValuePtr.ref.lpVtbl == nullptr) {
+      if (retValuePtr.ref.isNull) {
         free(retValuePtr);
         return null;
       }

--- a/packages/windows_foundation/lib/src/helpers.dart
+++ b/packages/windows_foundation/lib/src/helpers.dart
@@ -12,6 +12,11 @@ import 'package:win32/win32.dart';
 import 'iinspectable.dart';
 import 'winrt_enum.dart';
 
+extension NullCheckHelper on COMObject {
+  /// Whether the [lpVtbl] pointer is null.
+  bool get isNull => lpVtbl.address == 0;
+}
+
 extension WinRTStringConversion on Pointer<HSTRING> {
   /// Gets the Dart string at the handle pointed to by this object.
   String toDartString() => convertFromHString(value);

--- a/packages/windows_foundation/lib/src/iasyncoperation.dart
+++ b/packages/windows_foundation/lib/src/iasyncoperation.dart
@@ -294,7 +294,7 @@ class _IAsyncOperationInspectable<T> extends IAsyncOperation<T> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null as T;
     }
@@ -429,7 +429,7 @@ class _IAsyncOperationObject extends IAsyncOperation<Object?> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -488,7 +488,7 @@ class _IAsyncOperationUri extends IAsyncOperation<Uri?> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_foundation/lib/src/internal/comobject_pointer.dart
+++ b/packages/windows_foundation/lib/src/internal/comobject_pointer.dart
@@ -9,6 +9,8 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
 
+import '../helpers.dart';
+
 extension COMObjectPointer on Pointer<COMObject> {
   /// Creates a [List] from `Pointer<COMObject>`.
   ///
@@ -29,7 +31,7 @@ extension COMObjectPointer on Pointer<COMObject> {
 
     for (var i = 0; i < length; i++) {
       final objectPtr = this.elementAt(i);
-      if (objectPtr.ref.lpVtbl == nullptr) break;
+      if (objectPtr.ref.isNull) break;
       // Move each element to a newly allocated pointer so that it can be
       // freed properly.
       final newObjectPtr = calloc<COMObject>()..ref = objectPtr.ref;

--- a/packages/windows_foundation/lib/src/internal/ipropertyvalue_helpers.dart
+++ b/packages/windows_foundation/lib/src/internal/ipropertyvalue_helpers.dart
@@ -22,7 +22,7 @@ import 'int_array.dart';
 extension IPropertyValueHelper on IPropertyValue {
   /// Gets the type that is represented as an [IPropertyValue].
   Object? get value {
-    if (ptr.ref.lpVtbl == nullptr) return null;
+    if (ptr.ref.isNull) return null;
 
     // If the object does not implement the IPropertyValue interface, return it
     // as an IInspectable object.

--- a/packages/windows_foundation/lib/src/ireference.dart
+++ b/packages/windows_foundation/lib/src/ireference.dart
@@ -98,7 +98,7 @@ class _IReferenceBool extends IReference<bool?> {
 
   @override
   bool? get value {
-    if (ptr.ref.lpVtbl == nullptr) return null;
+    if (ptr.ref.isNull) return null;
 
     final retValuePtr = calloc<Bool>();
 
@@ -127,7 +127,7 @@ class _IReferenceDateTime extends IReference<DateTime?> {
 
   @override
   DateTime? get value {
-    if (ptr.ref.lpVtbl == nullptr) return null;
+    if (ptr.ref.isNull) return null;
 
     final retValuePtr = calloc<Uint64>();
 
@@ -159,7 +159,7 @@ class _IReferenceDouble extends IReference<double?> {
 
   @override
   double? get value {
-    if (ptr.ref.lpVtbl == nullptr) return null;
+    if (ptr.ref.isNull) return null;
     switch (referenceIid) {
       case IID_IReference_Double:
         return _getDouble();
@@ -220,7 +220,7 @@ class IReferenceDuration extends IReference<Duration?> {
 
   @override
   Duration? get value {
-    if (ptr.ref.lpVtbl == nullptr) return null;
+    if (ptr.ref.isNull) return null;
 
     final retValuePtr = calloc<Uint64>();
 
@@ -249,7 +249,7 @@ class _IReferenceGuid extends IReference<Guid?> {
 
   @override
   Guid? get value {
-    if (ptr.ref.lpVtbl == nullptr) return null;
+    if (ptr.ref.isNull) return null;
 
     final retValuePtr = calloc<GUID>();
 
@@ -280,7 +280,7 @@ class _IReferenceInt extends IReference<int?> {
 
   @override
   int? get value {
-    if (ptr.ref.lpVtbl == nullptr) return null;
+    if (ptr.ref.isNull) return null;
     switch (referenceIid) {
       case IID_IReference_Int16:
         return _getInt16();
@@ -437,7 +437,7 @@ class _IReferencePoint extends IReference<Point?> {
 
   @override
   Point? get value {
-    if (ptr.ref.lpVtbl == nullptr) return null;
+    if (ptr.ref.isNull) return null;
 
     final retValuePtr = calloc<Point>();
 
@@ -462,7 +462,7 @@ class _IReferenceRect extends IReference<Rect?> {
 
   @override
   Rect? get value {
-    if (ptr.ref.lpVtbl == nullptr) return null;
+    if (ptr.ref.isNull) return null;
 
     final retValuePtr = calloc<Rect>();
 
@@ -486,7 +486,7 @@ class _IReferenceSize extends IReference<Size?> {
 
   @override
   Size? get value {
-    if (ptr.ref.lpVtbl == nullptr) return null;
+    if (ptr.ref.isNull) return null;
 
     final retValuePtr = calloc<Size>();
 
@@ -514,7 +514,7 @@ class _IReferenceEnum<T> extends IReference<T> {
 
   @override
   T get value {
-    if (ptr.ref.lpVtbl == nullptr) return null as T;
+    if (ptr.ref.isNull) return null as T;
     switch (referenceIid) {
       // Int32 enumerations
       case IID_IReference_AdaptiveMediaSourceResourceType:

--- a/packages/windows_foundation/lib/src/iuriruntimeclass.dart
+++ b/packages/windows_foundation/lib/src/iuriruntimeclass.dart
@@ -260,7 +260,7 @@ class IUriRuntimeClass extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -431,7 +431,7 @@ class IUriRuntimeClass extends IInspectable {
 
     WindowsDeleteString(relativeUriHString);
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_gaming/lib/src/input/igamecontroller.dart
+++ b/packages/windows_gaming/lib/src/input/igamecontroller.dart
@@ -167,7 +167,7 @@ class IGameController extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -215,7 +215,7 @@ class IGameController extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_gaming/lib/src/input/igamecontrollerbatteryinfo.dart
+++ b/packages/windows_gaming/lib/src/input/igamecontrollerbatteryinfo.dart
@@ -47,7 +47,7 @@ class IGameControllerBatteryInfo extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_gaming/lib/src/input/igamepadstatics2.dart
+++ b/packages/windows_gaming/lib/src/input/igamepadstatics2.dart
@@ -55,7 +55,7 @@ class IGamepadStatics2 extends IInspectable implements IGamepadStatics {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_globalization/lib/src/icalendar.dart
+++ b/packages/windows_globalization/lib/src/icalendar.dart
@@ -48,7 +48,7 @@ class ICalendar extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_networking/lib/src/connectivity/iipinformation.dart
+++ b/packages/windows_networking/lib/src/connectivity/iipinformation.dart
@@ -47,7 +47,7 @@ class IIPInformation extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -73,7 +73,7 @@ class IIPInformation extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_networking/lib/src/connectivity/inetworkadapter.dart
+++ b/packages/windows_networking/lib/src/connectivity/inetworkadapter.dart
@@ -115,7 +115,7 @@ class INetworkAdapter extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_networking/lib/src/ihostname.dart
+++ b/packages/windows_networking/lib/src/ihostname.dart
@@ -49,7 +49,7 @@ class IHostName extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/iuserdatapathsstatics.dart
+++ b/packages/windows_storage/lib/src/iuserdatapathsstatics.dart
@@ -53,7 +53,7 @@ class IUserDataPathsStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -79,7 +79,7 @@ class IUserDataPathsStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/pickers/ifileopenpicker3.dart
+++ b/packages/windows_storage/lib/src/pickers/ifileopenpicker3.dart
@@ -47,7 +47,7 @@ class IFileOpenPicker3 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/pickers/ifileopenpickerstatics2.dart
+++ b/packages/windows_storage/lib/src/pickers/ifileopenpickerstatics2.dart
@@ -53,7 +53,7 @@ class IFileOpenPickerStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ui/lib/src/notifications/itoastnotification.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotification.dart
@@ -47,7 +47,7 @@ class IToastNotification extends IInspectable {
   //     throw WindowsException(hr);
   //   }
 
-  //   if (retValuePtr.ref.lpVtbl == nullptr) {
+  //   if (retValuePtr.ref.isNull) {
   //     free(retValuePtr);
   //     return null;
   //   }
@@ -87,7 +87,7 @@ class IToastNotification extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ui/lib/src/notifications/itoastnotification4.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotification4.dart
@@ -47,7 +47,7 @@ class IToastNotification4 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/winrtgen/lib/src/projections/types/class.dart
+++ b/packages/winrtgen/lib/src/projections/types/class.dart
@@ -24,7 +24,7 @@ mixin _ClassProjection on MethodProjection {
   String get nullCheck {
     if (!methodReturnType.endsWith('?')) return '';
     return '''
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/winrtgen/lib/src/projections/types/interface.dart
+++ b/packages/winrtgen/lib/src/projections/types/interface.dart
@@ -42,7 +42,7 @@ mixin _InterfaceProjection on MethodProjection {
   String get nullCheck {
     if (!methodReturnType.endsWith('?')) return '';
     return '''
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/winrtgen/lib/src/projections/types/object.dart
+++ b/packages/winrtgen/lib/src/projections/types/object.dart
@@ -29,7 +29,7 @@ mixin _ObjectProjection on MethodProjection {
   String get nullCheck => isMethodFromPropertyValueStatics
       ? ''
       : '''
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }''';

--- a/packages/winrtgen/lib/src/projections/types/reference.dart
+++ b/packages/winrtgen/lib/src/projections/types/reference.dart
@@ -77,7 +77,7 @@ mixin _ReferenceProjection on MethodProjection {
   }
 
   String get nullCheck => '''
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/winrtgen/lib/src/projections/types/uri.dart
+++ b/packages/winrtgen/lib/src/projections/types/uri.dart
@@ -9,7 +9,7 @@ import '../setter.dart';
 
 mixin _UriProjection on MethodProjection {
   String get nullCheck => '''
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/winrtgen/test/goldens/icalendar.golden
+++ b/packages/winrtgen/test/goldens/icalendar.golden
@@ -48,7 +48,7 @@ class ICalendar extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.lpVtbl == nullptr) {
+    if (retValuePtr.ref.isNull) {
       free(retValuePtr);
       return null;
     }


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

Replaces `ptr.ref.lpVtbl == nullptr` checks with `ptr.ref.isNull`. 

`isNull` extension getter checks whether the `lpVtbl`'s address is `0` to determine if it is `null`. 

Based on the micro benchmarks I've done, this seems to be **~50%** _faster_ compared to `ptr.ref.lpVtbl == nullptr`.

## Related Issue

None

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
