### PR TITLE
Move type check helpers into the `internal` library

### DIFF
--- a/packages/windows_foundation/lib/internal.dart
+++ b/packages/windows_foundation/lib/internal.dart
@@ -14,6 +14,7 @@ export 'src/internal/hstring_array.dart';
 export 'src/internal/iids.dart';
 export 'src/internal/int_array.dart';
 export 'src/internal/ipropertyvalue_helpers.dart';
+export 'src/internal/type_check_helpers.dart';
 export 'src/ipropertyvalue.dart';
 export 'src/ireference.dart';
 export 'src/propertyvalue.dart';

--- a/packages/windows_foundation/lib/src/collections/iiterator.dart
+++ b/packages/windows_foundation/lib/src/collections/iiterator.dart
@@ -7,6 +7,7 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
 
+import '../../internal.dart';
 import '../helpers.dart';
 import '../iinspectable.dart';
 import '../types.dart';

--- a/packages/windows_foundation/lib/src/helpers.dart
+++ b/packages/windows_foundation/lib/src/helpers.dart
@@ -10,7 +10,6 @@ import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
 
 import 'iinspectable.dart';
-import 'winrt_enum.dart';
 
 extension NullCheckHelper on COMObject {
   /// Whether the [lpVtbl] pointer is null.
@@ -129,57 +128,6 @@ void _initializeMTA() {
     free(pCookie);
   }
 }
-
-/// Determines whether [S] is the same type as [T].
-///
-/// ```dart
-/// isSameType<bool?, bool?>(); // true
-/// isSameType<String, String?>(); // false
-/// ```
-bool isSameType<S, T>() {
-  void func<X extends S>() {}
-  return func is void Function<X extends T>();
-}
-
-/// Determines whether [T] is `Object?`.
-///
-/// ```dart
-/// isNullableObjectType<Object?>(); // true
-/// isNullableObjectType<Object>(); // false
-/// ```
-bool isNullableObjectType<T>() => isSameType<T, Object?>();
-
-/// Determines whether [S] is a subtype of [T] or [T?].
-///
-/// ```dart
-/// isSubtype<Calendar, IInspectable>(); // true
-/// isSubtype<IUnknown, IInspectable>(); // false
-/// ```
-bool isSubtype<S, T>() => <S>[] is List<T> || <S>[] is List<T?>;
-
-/// Determines whether [T] is a subtype of [IInspectable].
-///
-/// ```dart
-/// isSubtypeOfInspectable<StorageFile>(); // true
-/// isSubtypeOfInspectable<INetwork>(); // false
-/// ```
-bool isSubtypeOfInspectable<T>() => isSubtype<T, IInspectable>();
-
-/// Determines whether [T] is a subtype of [Struct].
-///
-/// ```dart
-/// isSubtypeOfStruct<Point>(); // true
-/// isSubtypeOfStruct<GUID>(); // true
-/// ```
-bool isSubtypeOfStruct<T>() => isSubtype<T, Struct>();
-
-/// Determines whether [T] is a subtype of [WinRTEnum].
-///
-/// ```dart
-/// isSubtypeOfWinRTEnum<AsyncStatus>(); // true
-/// isSubtypeOfWinRTEnum<FileAttributes>(); // true
-/// ```
-bool isSubtypeOfWinRTEnum<T>() => isSubtype<T, WinRTEnum>();
 
 /// Represents the trust level of an activatable class.
 ///

--- a/packages/windows_foundation/lib/src/iasyncoperation.dart
+++ b/packages/windows_foundation/lib/src/iasyncoperation.dart
@@ -7,10 +7,8 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
 
+import '../internal.dart';
 import 'exports.g.dart';
-import 'iasyncinfo.dart';
-import 'internal/ipropertyvalue_helpers.dart';
-import 'ipropertyvalue.dart';
 import 'uri.dart' as winrt_uri;
 
 /// Represents an asynchronous operation, which returns a result upon

--- a/packages/windows_foundation/lib/src/internal/type_check_helpers.dart
+++ b/packages/windows_foundation/lib/src/internal/type_check_helpers.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:ffi';
+
+import '../iinspectable.dart';
+import '../winrt_enum.dart';
+
+/// Determines whether [S] is the same type as [T].
+///
+/// ```dart
+/// isSameType<bool?, bool?>(); // true
+/// isSameType<String, String?>(); // false
+/// ```
+bool isSameType<S, T>() {
+  void func<X extends S>() {}
+  return func is void Function<X extends T>();
+}
+
+/// Determines whether [T] is `Object?`.
+///
+/// ```dart
+/// isNullableObjectType<Object?>(); // true
+/// isNullableObjectType<Object>(); // false
+/// ```
+bool isNullableObjectType<T>() => isSameType<T, Object?>();
+
+/// Determines whether [S] is a subtype of [T] or [T?].
+///
+/// ```dart
+/// isSubtype<Calendar, IInspectable>(); // true
+/// isSubtype<IUnknown, IInspectable>(); // false
+/// ```
+bool isSubtype<S, T>() => <S>[] is List<T> || <S>[] is List<T?>;
+
+/// Determines whether [T] is a subtype of [IInspectable].
+///
+/// ```dart
+/// isSubtypeOfInspectable<StorageFile>(); // true
+/// isSubtypeOfInspectable<INetwork>(); // false
+/// ```
+bool isSubtypeOfInspectable<T>() => isSubtype<T, IInspectable>();
+
+/// Determines whether [T] is a subtype of [Struct].
+///
+/// ```dart
+/// isSubtypeOfStruct<Point>(); // true
+/// isSubtypeOfStruct<GUID>(); // true
+/// ```
+bool isSubtypeOfStruct<T>() => isSubtype<T, Struct>();
+
+/// Determines whether [T] is a subtype of [WinRTEnum].
+///
+/// ```dart
+/// isSubtypeOfWinRTEnum<AsyncStatus>(); // true
+/// isSubtypeOfWinRTEnum<FileAttributes>(); // true
+/// ```
+bool isSubtypeOfWinRTEnum<T>() => isSubtype<T, WinRTEnum>();

--- a/packages/windows_foundation/test/helpers_test.dart
+++ b/packages/windows_foundation/test/helpers_test.dart
@@ -2,54 +2,73 @@
 // details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn('windows')
+
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
 import 'package:test/test.dart';
 import 'package:win32/win32.dart';
-import 'package:windows_foundation/internal.dart';
 import 'package:windows_foundation/windows_foundation.dart';
 
 // Test the WinRT helper functions to make sure everything is working correctly.
 
 void main() {
-  test('isNullableObjectType', () {
-    expect(isNullableObjectType<Object?>(), isTrue);
-    expect(isNullableObjectType<Object>(), isFalse);
-    expect(isNullableObjectType<String?>(), isFalse);
-    expect(isNullableObjectType<String>(), isFalse);
+  test('isNull', () {
+    final ptr = calloc<COMObject>();
+
+    expect(ptr.ref.isNull, isTrue);
+
+    free(ptr);
   });
 
-  test('isSameType', () {
-    expect(isSameType<Guid, Guid>(), isTrue);
-    expect(isSameType<Object, Object>(), isTrue);
-    expect(isSameType<Object, Object?>(), isFalse);
-    expect(isSameType<Object?, Object?>(), isTrue);
-    expect(isSameType<String, String>(), isTrue);
-    expect(isSameType<String?, String>(), isFalse);
+  test('toDartString', () {
+    final hString = convertToHString('Hello, world!');
+    final ptr = calloc<HSTRING>()..value = hString;
+
+    expect(ptr.toDartString(), 'Hello, world!');
+
+    WindowsDeleteString(hString);
+    free(ptr);
   });
 
-  test('isSubtype', () {
-    expect(isSubtype<StringMap, IInspectable>(), isTrue);
-    expect(isSubtype<IAsyncInfo, IInspectable>(), isTrue);
-    expect(isSubtype<IUnknown, IInspectable>(), isFalse);
-    expect(isSubtype<IInspectable, IUnknown>(), isTrue);
+  test('getInterfaces', () {
+    const iids = [
+      '{f6d1f700-49c2-52ae-8154-826f9908773c}', // IMap<String, String>
+      '{e9bdaaf0-cbf6-5c72-be90-29cbf3a1319b}', // IIterable<IKeyValuePair<String, String>
+      '{1e036276-2f60-55f6-b7f3-f86079e6900b}', // IObservableMap<String, String>
+      '{00000038-0000-0000-c000-000000000046}' // IWeakReferenceSource
+    ];
+
+    final stringMap = StringMap();
+    expect(getInterfaces(stringMap), equals(iids));
+
+    stringMap.release();
   });
 
-  test('isSubtypeOfInspectable', () {
-    expect(isSubtypeOfInspectable<IInspectable>(), isTrue);
-    expect(isSubtypeOfInspectable<StringMap>(), isTrue);
-    expect(isSubtypeOfInspectable<IAsyncInfo>(), isTrue);
-    expect(isSubtypeOfInspectable<IUnknown>(), isFalse);
-    expect(isSubtypeOfInspectable<INetwork>(), isFalse);
+  test('getClassName', () {
+    const stringMapClassName = 'Windows.Foundation.Collections.StringMap';
+
+    final stringMap = StringMap();
+    expect(getClassName(stringMap), equals(stringMapClassName));
+
+    stringMap.release();
   });
 
-  test('isSubtypeOfStruct', () {
-    expect(isSubtypeOfStruct<GUID>(), isTrue);
-    expect(isSubtypeOfStruct<Guid>(), isFalse);
-    expect(isSubtypeOfStruct<Point>(), isTrue);
+  test('getTrustLevel of base trust class', () {
+    final stringMap = StringMap();
+    expect(getTrustLevel(stringMap), equals(TrustLevel.baseTrust));
+
+    stringMap.release();
   });
 
-  test('isSubtypeOfWinRTEnum', () {
-    expect(isSubtypeOfWinRTEnum<WinRTEnum>(), isTrue);
-    expect(isSubtypeOfWinRTEnum<AsyncStatus>(), isTrue);
-    expect(isSubtypeOfWinRTEnum<IAsyncAction>(), isFalse);
+  test('getTrustLevel of partial trust class', () {
+    const className = 'Windows.Storage.Pickers.FileOpenPicker';
+
+    final object = createObject(className, IID_IInspectable);
+    final inspectableObject = IInspectable(object);
+    expect(getTrustLevel(inspectableObject), equals(TrustLevel.partialTrust));
+
+    inspectableObject.release();
   });
 }

--- a/packages/windows_foundation/test/type_check_helpers_test.dart
+++ b/packages/windows_foundation/test/type_check_helpers_test.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2023, the dartwinrt authors. Please see the AUTHORS file for
+// details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+import 'package:win32/win32.dart';
+import 'package:windows_foundation/internal.dart';
+import 'package:windows_foundation/windows_foundation.dart';
+
+void main() {
+  test('isNullableObjectType', () {
+    expect(isNullableObjectType<Object?>(), isTrue);
+    expect(isNullableObjectType<Object>(), isFalse);
+    expect(isNullableObjectType<String?>(), isFalse);
+    expect(isNullableObjectType<String>(), isFalse);
+  });
+
+  test('isSameType', () {
+    expect(isSameType<Guid, Guid>(), isTrue);
+    expect(isSameType<Object, Object>(), isTrue);
+    expect(isSameType<Object, Object?>(), isFalse);
+    expect(isSameType<Object?, Object?>(), isTrue);
+    expect(isSameType<String, String>(), isTrue);
+    expect(isSameType<String?, String>(), isFalse);
+  });
+
+  test('isSubtype', () {
+    expect(isSubtype<StringMap, IInspectable>(), isTrue);
+    expect(isSubtype<IAsyncInfo, IInspectable>(), isTrue);
+    expect(isSubtype<IUnknown, IInspectable>(), isFalse);
+    expect(isSubtype<IInspectable, IUnknown>(), isTrue);
+  });
+
+  test('isSubtypeOfInspectable', () {
+    expect(isSubtypeOfInspectable<IInspectable>(), isTrue);
+    expect(isSubtypeOfInspectable<StringMap>(), isTrue);
+    expect(isSubtypeOfInspectable<IAsyncInfo>(), isTrue);
+    expect(isSubtypeOfInspectable<IUnknown>(), isFalse);
+    expect(isSubtypeOfInspectable<INetwork>(), isFalse);
+  });
+
+  test('isSubtypeOfStruct', () {
+    expect(isSubtypeOfStruct<GUID>(), isTrue);
+    expect(isSubtypeOfStruct<Guid>(), isFalse);
+    expect(isSubtypeOfStruct<Point>(), isTrue);
+  });
+
+  test('isSubtypeOfWinRTEnum', () {
+    expect(isSubtypeOfWinRTEnum<WinRTEnum>(), isTrue);
+    expect(isSubtypeOfWinRTEnum<AsyncStatus>(), isTrue);
+    expect(isSubtypeOfWinRTEnum<IAsyncAction>(), isFalse);
+  });
+}

--- a/packages/windows_foundation/test/winrt_test.dart
+++ b/packages/windows_foundation/test/winrt_test.dart
@@ -7,89 +7,50 @@
 import 'package:test/test.dart';
 import 'package:win32/win32.dart';
 import 'package:windows_foundation/internal.dart';
-import 'package:windows_foundation/windows_foundation.dart';
 
 void main() {
   if (isWindowsRuntimeAvailable()) {
-    test('WinRT initialization should succeed', () {
-      final hr = RoInitialize(RO_INIT_TYPE.RO_INIT_MULTITHREADED);
-      expect(hr, equals(S_OK));
-      RoUninitialize();
-    });
+    group('WinRT', () {
+      test('initialization should succeed', () {
+        final hr = RoInitialize(RO_INIT_TYPE.RO_INIT_MULTITHREADED);
+        expect(hr, equals(S_OK));
+        RoUninitialize();
+      });
 
-    test('WinRT double initialization should succeed with warning', () {
-      final hr = RoInitialize(RO_INIT_TYPE.RO_INIT_MULTITHREADED);
-      expect(SUCCEEDED(hr), isTrue);
-      expect(hr, equals(S_OK));
+      test('double initialization should succeed with warning', () {
+        final hr = RoInitialize(RO_INIT_TYPE.RO_INIT_MULTITHREADED);
+        expect(SUCCEEDED(hr), isTrue);
+        expect(hr, equals(S_OK));
 
-      final hr2 = RoInitialize(RO_INIT_TYPE.RO_INIT_MULTITHREADED);
-      expect(SUCCEEDED(hr2), isTrue);
-      expect(hr2, equals(S_FALSE));
+        final hr2 = RoInitialize(RO_INIT_TYPE.RO_INIT_MULTITHREADED);
+        expect(SUCCEEDED(hr2), isTrue);
+        expect(hr2, equals(S_FALSE));
 
-      // Balance out uninitialization. This is deliberately called twice.
-      RoUninitialize();
-      RoUninitialize();
-    });
+        // Balance out uninitialization. This is deliberately called twice.
+        RoUninitialize();
+        RoUninitialize();
+      });
 
-    test('WinRT change of threading model should fail', () {
-      final hr = RoInitialize(RO_INIT_TYPE.RO_INIT_MULTITHREADED);
-      expect(SUCCEEDED(hr), isTrue);
-      expect(hr, equals(S_OK));
+      test('change of threading model should fail', () {
+        final hr = RoInitialize(RO_INIT_TYPE.RO_INIT_MULTITHREADED);
+        expect(SUCCEEDED(hr), isTrue);
+        expect(hr, equals(S_OK));
 
-      final hr2 = RoInitialize(RO_INIT_TYPE.RO_INIT_SINGLETHREADED);
-      expect(FAILED(hr2), isTrue);
-      expect(hr2, equals(RPC_E_CHANGED_MODE));
+        final hr2 = RoInitialize(RO_INIT_TYPE.RO_INIT_SINGLETHREADED);
+        expect(FAILED(hr2), isTrue);
+        expect(hr2, equals(RPC_E_CHANGED_MODE));
 
-      // Balance out uninitialization. This is deliberately only called once,
-      // because it only succeeded once.
-      RoUninitialize();
-    });
+        // Balance out uninitialization. This is deliberately only called once,
+        // because it only succeeded once.
+        RoUninitialize();
+      });
 
-    test('WinRT basic test', () {
-      final propertyValue = PropertyValue.createString('basic');
-      expect(propertyValue.getString(), equals('basic'));
+      test('basic test', () {
+        final propertyValue = PropertyValue.createString('basic');
+        expect(propertyValue.getString(), equals('basic'));
 
-      propertyValue.release();
-    });
-
-    test('WinRT getInterfaces test', () {
-      const iids = [
-        '{f6d1f700-49c2-52ae-8154-826f9908773c}', // IMap<String, String>
-        '{e9bdaaf0-cbf6-5c72-be90-29cbf3a1319b}', // IIterable<IKeyValuePair<String, String>
-        '{1e036276-2f60-55f6-b7f3-f86079e6900b}', // IObservableMap<String, String>
-        '{00000038-0000-0000-c000-000000000046}' // IWeakReferenceSource
-      ];
-
-      final stringMap = StringMap();
-      expect(getInterfaces(stringMap), equals(iids));
-
-      stringMap.release();
-    });
-
-    test('WinRT getClassName test', () {
-      const stringMapClassName = 'Windows.Foundation.Collections.StringMap';
-
-      final stringMap = StringMap();
-      expect(getClassName(stringMap), equals(stringMapClassName));
-
-      stringMap.release();
-    });
-
-    test('WinRT getTrustLevel test of base trust class', () {
-      final stringMap = StringMap();
-      expect(getTrustLevel(stringMap), equals(TrustLevel.baseTrust));
-
-      stringMap.release();
-    });
-
-    test('WinRT getTrustLevel test of partial trust class', () {
-      const className = 'Windows.Storage.Pickers.FileOpenPicker';
-
-      final object = createObject(className, IID_IInspectable);
-      final inspectableObject = IInspectable(object);
-      expect(getTrustLevel(inspectableObject), equals(TrustLevel.partialTrust));
-
-      inspectableObject.release();
+        propertyValue.release();
+      });
     });
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

- Moves type check helpers into the `internal` library
- Adds tests for `isNull` extension getter and `toDartString()` extension method

## Related Issue

None

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
