### PR TITLE
Refactor WinRT Flags enum projection

### DIFF
--- a/packages/windows_devices/lib/src/enumeration/enums.g.dart
+++ b/packages/windows_devices/lib/src/enumeration/enums.g.dart
@@ -38,7 +38,8 @@ enum DeviceClass implements WinRTEnum {
 /// object.
 ///
 /// {@category enum}
-class DevicePickerDisplayStatusOptions extends WinRTEnum {
+class DevicePickerDisplayStatusOptions
+    extends WinRTFlagsEnum<DevicePickerDisplayStatusOptions> {
   const DevicePickerDisplayStatusOptions(super.value, {super.name});
 
   factory DevicePickerDisplayStatusOptions.from(int value) =>
@@ -61,26 +62,13 @@ class DevicePickerDisplayStatusOptions extends WinRTEnum {
     showRetryButton
   ];
 
+  @override
   DevicePickerDisplayStatusOptions operator &(
           DevicePickerDisplayStatusOptions other) =>
       DevicePickerDisplayStatusOptions(value & other.value);
 
+  @override
   DevicePickerDisplayStatusOptions operator |(
           DevicePickerDisplayStatusOptions other) =>
       DevicePickerDisplayStatusOptions(value | other.value);
-
-  /// Determines whether one or more bit fields are set in the current enum
-  /// value.
-  ///
-  /// ```dart
-  /// final fileAttributes = FileAttributes.readOnly | FileAttributes.archive;
-  /// fileAttributes.hasFlag(FileAttributes.readOnly)); // `true`
-  /// fileAttributes.hasFlag(FileAttributes.temporary)); // `false`
-  /// fileAttributes.hasFlag(
-  ///     FileAttributes.readOnly | FileAttributes.archive)); // `true`
-  /// ```
-  bool hasFlag(DevicePickerDisplayStatusOptions flag) {
-    if (value != 0 && flag.value == 0) return false;
-    return value & flag.value == flag.value;
-  }
 }

--- a/packages/windows_devices/lib/src/enumeration/idevicepickerfilter.dart
+++ b/packages/windows_devices/lib/src/enumeration/idevicepickerfilter.dart
@@ -50,8 +50,7 @@ class IDevicePickerFilter extends IInspectable {
 
     return IVector.fromRawPointer(retValuePtr,
         iterableIid: '{47d4be05-58f1-522e-81c6-975eb4131bb9}',
-        enumCreator: DeviceClass.from,
-        intType: WinRTIntType.int32);
+        enumCreator: DeviceClass.from);
   }
 
   IVector<String> get supportedDeviceSelectors {

--- a/packages/windows_devices/lib/src/geolocation/igeolocatorstatics.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeolocatorstatics.dart
@@ -52,8 +52,7 @@ class IGeolocatorStatics extends IInspectable {
 
     final asyncOperation =
         IAsyncOperation<GeolocationAccessStatus>.fromRawPointer(retValuePtr,
-            enumCreator: GeolocationAccessStatus.from,
-            intType: WinRTIntType.int32);
+            enumCreator: GeolocationAccessStatus.from);
     completeAsyncOperation(
         asyncOperation, completer, asyncOperation.getResults);
 

--- a/packages/windows_foundation/lib/src/collections/iiterable.dart
+++ b/packages/windows_foundation/lib/src/collections/iiterable.dart
@@ -42,10 +42,10 @@ class IIterable<T> extends IInspectable {
   ///     creator: StorageFile.fromRawPointer);
   /// ```
   ///
-  /// [enumCreator] and [intType] must be specified if [T] is `WinRTEnum`.
+  /// [enumCreator] must be specified if [T] is `WinRTEnum`.
   /// ```dart
   /// final iterable = IIterable<DeviceClass>.fromRawPointer(ptr,
-  ///     enumCreator: DeviceClass.from, intType: WinRTIntType.int32);
+  ///     enumCreator: DeviceClass.from);
   /// ```
   IIterable.fromRawPointer(
     super.ptr, {
@@ -63,9 +63,8 @@ class IIterable<T> extends IInspectable {
       throw ArgumentError.notNull('creator');
     }
 
-    if (this is IIterable<WinRTEnum>) {
-      if (enumCreator == null) throw ArgumentError.notNull('enumCreator');
-      if (intType == null) throw ArgumentError.notNull('intType');
+    if (enumCreator == null && this is IIterable<WinRTEnum>) {
+      throw ArgumentError.notNull('enumCreator');
     }
   }
 

--- a/packages/windows_foundation/lib/src/collections/ikeyvaluepair.dart
+++ b/packages/windows_foundation/lib/src/collections/ikeyvaluepair.dart
@@ -91,6 +91,12 @@ abstract class IKeyValuePair<K, V> extends IInspectable {
 
       if (isSubtypeOfWinRTEnum<V>()) {
         if (enumCreator == null) throw ArgumentError.notNull('enumCreator');
+
+        if (isSubtypeOfWinRTFlagsEnum<V>()) {
+          return _IKeyValuePairStringFlagsEnum<V>.fromRawPointer(
+              ptr, enumCreator) as IKeyValuePair<K, V>;
+        }
+
         return _IKeyValuePairStringEnum<V>.fromRawPointer(ptr, enumCreator)
             as IKeyValuePair<K, V>;
       }
@@ -104,6 +110,12 @@ abstract class IKeyValuePair<K, V> extends IInspectable {
     if (isSubtypeOfWinRTEnum<K>() && isSubtypeOfInspectable<V>()) {
       if (enumKeyCreator == null) throw ArgumentError.notNull('enumKeyCreator');
       if (creator == null) throw ArgumentError.notNull('creator');
+
+      if (isSubtypeOfWinRTFlagsEnum<K>()) {
+        return _IKeyValuePairFlagsEnumInspectable.fromRawPointer(
+            ptr, creator, enumKeyCreator);
+      }
+
       return _IKeyValuePairEnumInspectable.fromRawPointer(
           ptr, creator, enumKeyCreator);
     }
@@ -119,6 +131,7 @@ abstract class IKeyValuePair<K, V> extends IInspectable {
 }
 
 class _IKeyValuePairEnumInspectable<K, V> extends IKeyValuePair<K, V> {
+  _IKeyValuePairEnumInspectable(super.ptr, this.creator, this.enumKeyCreator);
   _IKeyValuePairEnumInspectable.fromRawPointer(
       super.ptr, this.creator, this.enumKeyCreator);
 
@@ -153,6 +166,35 @@ class _IKeyValuePairEnumInspectable<K, V> extends IKeyValuePair<K, V> {
     final retVal = _valueCOMObject(ptr);
     if (retVal == null) return null as V;
     return creator(retVal);
+  }
+}
+
+class _IKeyValuePairFlagsEnumInspectable<K, V>
+    extends _IKeyValuePairEnumInspectable<K, V> {
+  _IKeyValuePairFlagsEnumInspectable.fromRawPointer(
+      super.ptr, super.creator, super.enumKeyCreator);
+
+  @override
+  K get key {
+    final retValuePtr = calloc<Uint32>();
+
+    try {
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(6)
+          .cast<
+              Pointer<
+                  NativeFunction<HRESULT Function(Pointer, Pointer<Uint32>)>>>()
+          .value
+          .asFunction<
+              int Function(
+                  Pointer, Pointer<Uint32>)>()(ptr.ref.lpVtbl, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      return enumKeyCreator(retValuePtr.value);
+    } finally {
+      free(retValuePtr);
+    }
   }
 }
 
@@ -219,6 +261,7 @@ class _IKeyValuePairIntInspectable<V> extends IKeyValuePair<int, V> {
 }
 
 class _IKeyValuePairStringEnum<V> extends IKeyValuePair<String, V> {
+  _IKeyValuePairStringEnum(super.ptr, this.enumCreator);
   _IKeyValuePairStringEnum.fromRawPointer(super.ptr, this.enumCreator);
 
   final V Function(int) enumCreator;
@@ -240,6 +283,33 @@ class _IKeyValuePairStringEnum<V> extends IKeyValuePair<String, V> {
           .asFunction<
               int Function(
                   Pointer, Pointer<Int32>)>()(ptr.ref.lpVtbl, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      return enumCreator(retValuePtr.value);
+    } finally {
+      free(retValuePtr);
+    }
+  }
+}
+
+class _IKeyValuePairStringFlagsEnum<V> extends _IKeyValuePairStringEnum<V> {
+  _IKeyValuePairStringFlagsEnum.fromRawPointer(super.ptr, super.enumCreator);
+
+  @override
+  V get value {
+    final retValuePtr = calloc<Uint32>();
+
+    try {
+      final hr = ptr.ref.lpVtbl.value
+          .elementAt(7)
+          .cast<
+              Pointer<
+                  NativeFunction<HRESULT Function(Pointer, Pointer<Uint32>)>>>()
+          .value
+          .asFunction<
+              int Function(
+                  Pointer, Pointer<Uint32>)>()(ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/packages/windows_foundation/lib/src/collections/ivector.dart
+++ b/packages/windows_foundation/lib/src/collections/ivector.dart
@@ -48,10 +48,10 @@ abstract class IVector<T> extends IInspectable implements IIterable<T> {
   ///     iterableIid: '{9ac00304-83ea-5688-87b6-ae38aab65d0b}');
   /// ```
   ///
-  /// [enumCreator] and [intType] must be specified if [T] is `WinRTEnum`.
+  /// [enumCreator] must be specified if [T] is `WinRTEnum`.
   /// ```dart
   /// final vector = IVector<DeviceClass>.fromRawPointer(ptr,
-  ///     enumCreator: DeviceClass.from, intType: WinRTIntType.int32,
+  ///     enumCreator: DeviceClass.from,
   ///     iterableIid: '{47d4be05-58f1-522e-81c6-975eb4131bb9}');
   /// ```
   factory IVector.fromRawPointer(
@@ -82,9 +82,12 @@ abstract class IVector<T> extends IInspectable implements IIterable<T> {
 
     if (isSubtypeOfWinRTEnum<T>()) {
       if (enumCreator == null) throw ArgumentError.notNull('enumCreator');
-      if (intType == null) throw ArgumentError.notNull('intType');
-      return _IVectorEnum.fromRawPointer(
-          ptr, enumCreator, intType, iterableIid);
+
+      if (isSubtypeOfWinRTFlagsEnum<T>()) {
+        return _IVectorFlagsEnum.fromRawPointer(ptr, enumCreator, iterableIid);
+      }
+
+      return _IVectorEnum.fromRawPointer(ptr, enumCreator, iterableIid);
     }
 
     throw ArgumentError.value(T, 'T', 'Unsupported type');
@@ -180,12 +183,11 @@ abstract class IVector<T> extends IInspectable implements IIterable<T> {
 }
 
 class _IVectorEnum<T> extends IVector<T> {
-  _IVectorEnum.fromRawPointer(
-      super.ptr, this.enumCreator, this.intType, this.iterableIid);
+  _IVectorEnum.fromRawPointer(super.ptr, this.enumCreator, this.iterableIid);
 
   final T Function(int) enumCreator;
-  final WinRTIntType intType;
   final String iterableIid;
+  final intType = WinRTIntType.int32;
 
   @override
   T getAt(int index) => enumCreator(_getAtInt(ptr, intType, index));
@@ -215,15 +217,92 @@ class _IVectorEnum<T> extends IVector<T> {
 
   @override
   void replaceAll(List<T> value) {
-    switch (intType) {
-      case WinRTIntType.uint32:
-        final pArray = calloc<Uint32>(value.length);
-        for (var i = 0; i < value.length; i++) {
-          pArray[i] = (value.elementAt(i) as WinRTEnum).value;
-        }
+    final pArray = calloc<Int32>(value.length);
+    for (var i = 0; i < value.length; i++) {
+      pArray[i] = (value.elementAt(i) as WinRTEnum).value;
+    }
 
-        try {
-          final hr = ptr.ref.vtable
+    try {
+      final hr = ptr.ref.vtable
+              .elementAt(17)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          HRESULT Function(Pointer, Uint32, Pointer<Int32>)>>>()
+              .value
+              .asFunction<int Function(Pointer, int, Pointer<Int32>)>()(
+          ptr.ref.lpVtbl, value.length, pArray);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+    } finally {
+      free(pArray);
+    }
+  }
+
+  late final _iIterable = IIterable<T>.fromRawPointer(toInterface(iterableIid),
+      enumCreator: enumCreator);
+
+  @override
+  IIterator<T> first() => _iIterable.first();
+
+  @override
+  List<T> toList() {
+    if (size == 0) return List.unmodifiable(<T>[]);
+
+    final pArray = calloc<Int32>(size);
+    try {
+      getMany(0, size, pArray);
+      return List.unmodifiable(pArray.toList(length: size).map(enumCreator));
+    } finally {
+      free(pArray);
+    }
+  }
+}
+
+class _IVectorFlagsEnum<T> extends IVector<T> {
+  _IVectorFlagsEnum.fromRawPointer(
+      super.ptr, this.enumCreator, this.iterableIid);
+
+  final T Function(int) enumCreator;
+  final String iterableIid;
+  final intType = WinRTIntType.uint32;
+
+  @override
+  T getAt(int index) => enumCreator(_getAtInt(ptr, intType, index));
+
+  @override
+  List<T> getView() =>
+      _getView(ptr, iterableIid, enumCreator: enumCreator, intType: intType);
+
+  @override
+  bool indexOf(T value, Pointer<Uint32> index) =>
+      _indexOfInt(ptr, intType, (value as WinRTEnum).value, index);
+
+  @override
+  void setAt(int index, T value) =>
+      _setAtInt(ptr, intType, index, (value as WinRTEnum).value);
+
+  @override
+  void insertAt(int index, T value) =>
+      _insertAtInt(ptr, intType, index, (value as WinRTEnum).value);
+
+  @override
+  void append(T value) => _appendInt(ptr, intType, (value as WinRTEnum).value);
+
+  @override
+  int getMany(int startIndex, int capacity, Pointer<NativeType> value) =>
+      _getManyInt(ptr, intType, startIndex, capacity, value);
+
+  @override
+  void replaceAll(List<T> value) {
+    final pArray = calloc<Uint32>(value.length);
+    for (var i = 0; i < value.length; i++) {
+      pArray[i] = (value.elementAt(i) as WinRTEnum).value;
+    }
+
+    try {
+      final hr =
+          ptr.ref.vtable
                   .elementAt(17)
                   .cast<
                       Pointer<
@@ -234,39 +313,14 @@ class _IVectorEnum<T> extends IVector<T> {
                   .asFunction<int Function(Pointer, int, Pointer<Uint32>)>()(
               ptr.ref.lpVtbl, value.length, pArray);
 
-          if (FAILED(hr)) throw WindowsException(hr);
-        } finally {
-          free(pArray);
-        }
-        break;
-      default:
-        final pArray = calloc<Int32>(value.length);
-        for (var i = 0; i < value.length; i++) {
-          pArray[i] = (value.elementAt(i) as WinRTEnum).value;
-        }
-
-        try {
-          final hr =
-              ptr.ref.vtable
-                      .elementAt(17)
-                      .cast<
-                          Pointer<
-                              NativeFunction<
-                                  HRESULT Function(
-                                      Pointer, Uint32, Pointer<Int32>)>>>()
-                      .value
-                      .asFunction<int Function(Pointer, int, Pointer<Int32>)>()(
-                  ptr.ref.lpVtbl, value.length, pArray);
-
-          if (FAILED(hr)) throw WindowsException(hr);
-        } finally {
-          free(pArray);
-        }
+      if (FAILED(hr)) throw WindowsException(hr);
+    } finally {
+      free(pArray);
     }
   }
 
   late final _iIterable = IIterable<T>.fromRawPointer(toInterface(iterableIid),
-      enumCreator: enumCreator, intType: intType);
+      enumCreator: enumCreator);
 
   @override
   IIterator<T> first() => _iIterable.first();
@@ -275,27 +329,12 @@ class _IVectorEnum<T> extends IVector<T> {
   List<T> toList() {
     if (size == 0) return List.unmodifiable(<T>[]);
 
-    // The only valid types for enums are Int32 or UInt32.
-    // See https://docs.microsoft.com/en-us/uwp/winrt-cref/winrt-type-system#enums
-    switch (intType) {
-      case WinRTIntType.uint32:
-        final pArray = calloc<Uint32>(size);
-        try {
-          getMany(0, size, pArray);
-          return List.unmodifiable(
-              pArray.toList(length: size).map(enumCreator));
-        } finally {
-          free(pArray);
-        }
-      default:
-        final pArray = calloc<Int32>(size);
-        try {
-          getMany(0, size, pArray);
-          return List.unmodifiable(
-              pArray.toList(length: size).map(enumCreator));
-        } finally {
-          free(pArray);
-        }
+    final pArray = calloc<Uint32>(size);
+    try {
+      getMany(0, size, pArray);
+      return List.unmodifiable(pArray.toList(length: size).map(enumCreator));
+    } finally {
+      free(pArray);
     }
   }
 }

--- a/packages/windows_foundation/lib/src/internal/type_check_helpers.dart
+++ b/packages/windows_foundation/lib/src/internal/type_check_helpers.dart
@@ -57,3 +57,11 @@ bool isSubtypeOfStruct<T>() => isSubtype<T, Struct>();
 /// isSubtypeOfWinRTEnum<FileAttributes>(); // true
 /// ```
 bool isSubtypeOfWinRTEnum<T>() => isSubtype<T, WinRTEnum>();
+
+/// Determines whether [T] is a subtype of [WinRTEnum].
+///
+/// ```dart
+/// isSubtypeOfWinRTFlagsEnum<FileAttributes>(); // true
+/// isSubtypeOfWinRTFlagsEnum<AsyncStatus>(); // false
+/// ```
+bool isSubtypeOfWinRTFlagsEnum<T>() => isSubtype<T, WinRTFlagsEnum<dynamic>>();

--- a/packages/windows_foundation/lib/src/winrt_enum.dart
+++ b/packages/windows_foundation/lib/src/winrt_enum.dart
@@ -13,3 +13,39 @@ abstract class WinRTEnum {
   String toString() =>
       _name != null ? '$runtimeType.$_name' : '$runtimeType(value: $value)';
 }
+
+/// The base class that all WinRT Flags enumerations implement.
+abstract class WinRTFlagsEnum<T extends WinRTEnum> extends WinRTEnum {
+  const WinRTFlagsEnum(super.value, {super.name});
+
+  /// Bit-wise and operator.
+  ///
+  /// ```dart
+  /// FileAttributes.readOnly & FileAttributes.archive // 1 & 32 -> 0
+  /// FileAttributes.archive & FileAttributes.archive // 32 & 32 -> 32
+  /// ```
+  T operator &(T other);
+
+  /// Bit-wise or operator.
+  ///
+  /// ```dart
+  /// FileAttributes.readOnly | FileAttributes.archive // 1 | 32 -> 33
+  /// FileAttributes.archive | FileAttributes.archive // 32 | 32 -> 32
+  /// ```
+  T operator |(T other);
+
+  /// Determines whether one or more bit fields are set in the current enum
+  /// value.
+  ///
+  /// ```dart
+  /// final fileAttributes = FileAttributes.readOnly | FileAttributes.archive;
+  /// fileAttributes.hasFlag(FileAttributes.readOnly)); // `true`
+  /// fileAttributes.hasFlag(FileAttributes.temporary)); // `false`
+  /// fileAttributes.hasFlag(
+  ///     FileAttributes.readOnly | FileAttributes.archive)); // `true`
+  /// ```
+  bool hasFlag(T flag) {
+    if (value != 0 && flag.value == 0) return false;
+    return value & flag.value == flag.value;
+  }
+}

--- a/packages/windows_foundation/test/type_check_helpers_test.dart
+++ b/packages/windows_foundation/test/type_check_helpers_test.dart
@@ -50,4 +50,9 @@ void main() {
     expect(isSubtypeOfWinRTEnum<AsyncStatus>(), isTrue);
     expect(isSubtypeOfWinRTEnum<IAsyncAction>(), isFalse);
   });
+
+  test('isSubtypeOfWinRTFlagsEnum', () {
+    expect(isSubtypeOfWinRTFlagsEnum<WinRTFlagsEnum<dynamic>>(), isTrue);
+    expect(isSubtypeOfWinRTFlagsEnum<AsyncStatus>(), isFalse);
+  });
 }

--- a/packages/windows_gaming/lib/src/input/enums.g.dart
+++ b/packages/windows_gaming/lib/src/input/enums.g.dart
@@ -98,7 +98,7 @@ enum GameControllerButtonLabel implements WinRTEnum {
 /// Specifies the button type.
 ///
 /// {@category enum}
-class GamepadButtons extends WinRTEnum {
+class GamepadButtons extends WinRTFlagsEnum<GamepadButtons> {
   const GamepadButtons(super.value, {super.name});
 
   factory GamepadButtons.from(int value) => GamepadButtons.values
@@ -146,24 +146,11 @@ class GamepadButtons extends WinRTEnum {
     paddle4
   ];
 
+  @override
   GamepadButtons operator &(GamepadButtons other) =>
       GamepadButtons(value & other.value);
 
+  @override
   GamepadButtons operator |(GamepadButtons other) =>
       GamepadButtons(value | other.value);
-
-  /// Determines whether one or more bit fields are set in the current enum
-  /// value.
-  ///
-  /// ```dart
-  /// final fileAttributes = FileAttributes.readOnly | FileAttributes.archive;
-  /// fileAttributes.hasFlag(FileAttributes.readOnly)); // `true`
-  /// fileAttributes.hasFlag(FileAttributes.temporary)); // `false`
-  /// fileAttributes.hasFlag(
-  ///     FileAttributes.readOnly | FileAttributes.archive)); // `true`
-  /// ```
-  bool hasFlag(GamepadButtons flag) {
-    if (value != 0 && flag.value == 0) return false;
-    return value & flag.value == flag.value;
-  }
 }

--- a/packages/windows_networking/lib/src/connectivity/enums.g.dart
+++ b/packages/windows_networking/lib/src/connectivity/enums.g.dart
@@ -13,7 +13,7 @@ import 'package:windows_foundation/windows_foundation.dart';
 /// Defines the network connection types.
 ///
 /// {@category enum}
-class NetworkTypes extends WinRTEnum {
+class NetworkTypes extends WinRTFlagsEnum<NetworkTypes> {
   const NetworkTypes(super.value, {super.name});
 
   factory NetworkTypes.from(int value) => NetworkTypes.values
@@ -25,24 +25,11 @@ class NetworkTypes extends WinRTEnum {
 
   static const List<NetworkTypes> values = [none, internet, privateNetwork];
 
+  @override
   NetworkTypes operator &(NetworkTypes other) =>
       NetworkTypes(value & other.value);
 
+  @override
   NetworkTypes operator |(NetworkTypes other) =>
       NetworkTypes(value | other.value);
-
-  /// Determines whether one or more bit fields are set in the current enum
-  /// value.
-  ///
-  /// ```dart
-  /// final fileAttributes = FileAttributes.readOnly | FileAttributes.archive;
-  /// fileAttributes.hasFlag(FileAttributes.readOnly)); // `true`
-  /// fileAttributes.hasFlag(FileAttributes.temporary)); // `false`
-  /// fileAttributes.hasFlag(
-  ///     FileAttributes.readOnly | FileAttributes.archive)); // `true`
-  /// ```
-  bool hasFlag(NetworkTypes flag) {
-    if (value != 0 && flag.value == 0) return false;
-    return value & flag.value == flag.value;
-  }
 }

--- a/packages/windows_storage/lib/src/enums.g.dart
+++ b/packages/windows_storage/lib/src/enums.g.dart
@@ -13,7 +13,7 @@ import 'package:windows_foundation/windows_foundation.dart';
 /// Describes the attributes of a file or folder.
 ///
 /// {@category enum}
-class FileAttributes extends WinRTEnum {
+class FileAttributes extends WinRTFlagsEnum<FileAttributes> {
   const FileAttributes(super.value, {super.name});
 
   factory FileAttributes.from(int value) => FileAttributes.values
@@ -36,26 +36,13 @@ class FileAttributes extends WinRTEnum {
     locallyIncomplete
   ];
 
+  @override
   FileAttributes operator &(FileAttributes other) =>
       FileAttributes(value & other.value);
 
+  @override
   FileAttributes operator |(FileAttributes other) =>
       FileAttributes(value | other.value);
-
-  /// Determines whether one or more bit fields are set in the current enum
-  /// value.
-  ///
-  /// ```dart
-  /// final fileAttributes = FileAttributes.readOnly | FileAttributes.archive;
-  /// fileAttributes.hasFlag(FileAttributes.readOnly)); // `true`
-  /// fileAttributes.hasFlag(FileAttributes.temporary)); // `false`
-  /// fileAttributes.hasFlag(
-  ///     FileAttributes.readOnly | FileAttributes.archive)); // `true`
-  /// ```
-  bool hasFlag(FileAttributes flag) {
-    if (value != 0 && flag.value == 0) return false;
-    return value & flag.value == flag.value;
-  }
 }
 
 /// Specifies what to do if a file or folder with the specified name already
@@ -102,7 +89,7 @@ enum StorageDeleteOption implements WinRTEnum {
 /// a file or a folder.
 ///
 /// {@category enum}
-class StorageItemTypes extends WinRTEnum {
+class StorageItemTypes extends WinRTFlagsEnum<StorageItemTypes> {
   const StorageItemTypes(super.value, {super.name});
 
   factory StorageItemTypes.from(int value) =>
@@ -115,24 +102,11 @@ class StorageItemTypes extends WinRTEnum {
 
   static const List<StorageItemTypes> values = [none, file, folder];
 
+  @override
   StorageItemTypes operator &(StorageItemTypes other) =>
       StorageItemTypes(value & other.value);
 
+  @override
   StorageItemTypes operator |(StorageItemTypes other) =>
       StorageItemTypes(value | other.value);
-
-  /// Determines whether one or more bit fields are set in the current enum
-  /// value.
-  ///
-  /// ```dart
-  /// final fileAttributes = FileAttributes.readOnly | FileAttributes.archive;
-  /// fileAttributes.hasFlag(FileAttributes.readOnly)); // `true`
-  /// fileAttributes.hasFlag(FileAttributes.temporary)); // `false`
-  /// fileAttributes.hasFlag(
-  ///     FileAttributes.readOnly | FileAttributes.archive)); // `true`
-  /// ```
-  bool hasFlag(StorageItemTypes flag) {
-    if (value != 0 && flag.value == 0) return false;
-    return value & flag.value == flag.value;
-  }
 }

--- a/packages/winrtgen/lib/src/projections/enum.dart
+++ b/packages/winrtgen/lib/src/projections/enum.dart
@@ -117,7 +117,8 @@ class FlagsEnumProjection extends EnumProjection {
   }
 
   @override
-  String get classDeclaration => 'class $enumName extends WinRTEnum {';
+  String get classDeclaration =>
+      'class $enumName extends WinRTFlagsEnum<$enumName> {';
 
   @override
   String get constructor => 'const $enumName(super.value, {super.name});';
@@ -144,30 +145,15 @@ class FlagsEnumProjection extends EnumProjection {
   }
 
   String get andOperator => '''
-    $enumName operator &($enumName other) =>
-        $enumName(value & other.value);
+  @override
+  $enumName operator &($enumName other) =>
+      $enumName(value & other.value);
 ''';
 
   String get orOperator => '''
-    $enumName operator |($enumName other) =>
-        $enumName(value | other.value);
-''';
-
-  String get hasFlag => '''
-    /// Determines whether one or more bit fields are set in the current enum
-    /// value.
-    ///
-    /// ```dart
-    /// final fileAttributes = FileAttributes.readOnly | FileAttributes.archive;
-    /// fileAttributes.hasFlag(FileAttributes.readOnly)); // `true`
-    /// fileAttributes.hasFlag(FileAttributes.temporary)); // `false`
-    /// fileAttributes.hasFlag(
-    ///     FileAttributes.readOnly | FileAttributes.archive)); // `true`
-    /// ```
-    bool hasFlag($enumName flag) {
-      if (value != 0 && flag.value == 0) return false;
-      return value & flag.value == flag.value;
-    }
+  @override
+  $enumName operator |($enumName other) =>
+      $enumName(value | other.value);
 ''';
 
   @override
@@ -185,8 +171,6 @@ $classDeclaration
   $andOperator
 
   $orOperator
-
-  $hasFlag
 }
 ''';
 }

--- a/packages/winrtgen/lib/src/projections/types/async.dart
+++ b/packages/winrtgen/lib/src/projections/types/async.dart
@@ -61,10 +61,10 @@ mixin _AsyncOperationProjection on MethodProjection {
     // IAsyncOperation implementation can instantiate the object.
     final creator = returnType.typeIdentifier.typeArg!.creator;
 
-    // If the type argument is an enum or int, 'intType' parameter must be
-    // specified so that the IAsyncOperation implementation can use the
-    // appropriate native integer type
-    final intType = typeProjection.isWinRTEnum || asyncOperationTypeArg == 'int'
+    // If the type argument is an int, 'intType' parameter must be specified so
+    // that the IAsyncOperation implementation can use the appropriate native
+    // integer type
+    final intType = asyncOperationTypeArg == 'int'
         ? 'WinRTIntType.${typeProjection.nativeType.toLowerCase()}'
         : null;
 

--- a/packages/winrtgen/lib/src/projections/types/vector.dart
+++ b/packages/winrtgen/lib/src/projections/types/vector.dart
@@ -31,10 +31,10 @@ mixin _VectorProjection on MethodProjection {
     // when instantiating the IIterable object
     final iterableIid = iterableIidFromVectorType(returnType.typeIdentifier);
 
-    // If the type argument is an enum or int, 'intType' parameter must be
-    // specified so that the IVector and IVectorView implementations can use the
-    // appropriate native integer type
-    final intType = typeProjection.isWinRTEnum || vectorTypeArg == 'int'
+    // If the type argument is an int, 'intType' parameter must be specified so
+    // that the IVector and IVectorView implementations can use the appropriate
+    // native integer type
+    final intType = vectorTypeArg == 'int'
         ? 'WinRTIntType.${typeProjection.nativeType.toLowerCase()}'
         : null;
 

--- a/packages/winrtgen/test/projections/enum_test.dart
+++ b/packages/winrtgen/test/projections/enum_test.dart
@@ -103,8 +103,10 @@ void main() {
     });
 
     test('has correct class declaration', () {
-      expect(fileAttributesProjection.classDeclaration,
-          equals('class FileAttributes extends WinRTEnum {'));
+      expect(
+          fileAttributesProjection.classDeclaration,
+          equals(
+              'class FileAttributes extends WinRTFlagsEnum<FileAttributes> {'));
     });
 
     test('has correct identifiers', () {


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

- Adds `WinRTFlagsEnum` abstract class that extends the `WinRTEnum`
- Removes uses of the `intType` parameter for `WinRTEnum` type arguments (replaced with `isSubtypeOfWinRTFlagsEnum` checks)

## Related Issue

None

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
