### PR TITLE
Bump lower SDK bound to `>=2.19.2`

### DIFF
--- a/packages/windows_ai/pubspec.yaml
+++ b/packages/windows_ai/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/halildurmus/dartwinrt/issues?q=is%3Aopen+is%3A
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.2 <4.0.0'
 
 # Declare that this package only works on Windows.
 platforms:

--- a/packages/windows_applicationmodel/pubspec.yaml
+++ b/packages/windows_applicationmodel/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/halildurmus/dartwinrt/issues?q=is%3Aopen+is%3A
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.2 <4.0.0'
 
 # Declare that this package only works on Windows.
 platforms:

--- a/packages/windows_data/pubspec.yaml
+++ b/packages/windows_data/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/halildurmus/dartwinrt/issues?q=is%3Aopen+is%3A
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.2 <4.0.0'
 
 # Declare that this package only works on Windows.
 platforms:

--- a/packages/windows_devices/pubspec.yaml
+++ b/packages/windows_devices/pubspec.yaml
@@ -9,7 +9,7 @@ issue_tracker: https://github.com/halildurmus/dartwinrt/issues?q=is%3Aopen+is%3A
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.2 <4.0.0'
 
 # Declare that this package only works on Windows.
 platforms:

--- a/packages/windows_foundation/pubspec.yaml
+++ b/packages/windows_foundation/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/halildurmus/dartwinrt/issues?q=is%3Aopen+is%3A
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.2 <4.0.0'
 
 # Declare that this package only works on Windows.
 platforms:

--- a/packages/windows_gaming/pubspec.yaml
+++ b/packages/windows_gaming/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/halildurmus/dartwinrt/issues?q=is%3Aopen+is%3A
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.2 <4.0.0'
 
 # Declare that this package only works on Windows.
 platforms:

--- a/packages/windows_globalization/pubspec.yaml
+++ b/packages/windows_globalization/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/halildurmus/dartwinrt/issues?q=is%3Aopen+is%3A
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.2 <4.0.0'
 
 # Declare that this package only works on Windows.
 platforms:

--- a/packages/windows_graphics/pubspec.yaml
+++ b/packages/windows_graphics/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/halildurmus/dartwinrt/issues?q=is%3Aopen+is%3A
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.2 <4.0.0'
 
 # Declare that this package only works on Windows.
 platforms:

--- a/packages/windows_management/pubspec.yaml
+++ b/packages/windows_management/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/halildurmus/dartwinrt/issues?q=is%3Aopen+is%3A
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.2 <4.0.0'
 
 # Declare that this package only works on Windows.
 platforms:

--- a/packages/windows_media/pubspec.yaml
+++ b/packages/windows_media/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/halildurmus/dartwinrt/issues?q=is%3Aopen+is%3A
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.2 <4.0.0'
 
 # Declare that this package only works on Windows.
 platforms:

--- a/packages/windows_networking/pubspec.yaml
+++ b/packages/windows_networking/pubspec.yaml
@@ -9,7 +9,7 @@ issue_tracker: https://github.com/halildurmus/dartwinrt/issues?q=is%3Aopen+is%3A
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.2 <4.0.0'
 
 # Declare that this package only works on Windows.
 platforms:

--- a/packages/windows_perception/pubspec.yaml
+++ b/packages/windows_perception/pubspec.yaml
@@ -9,7 +9,7 @@ issue_tracker: https://github.com/halildurmus/dartwinrt/issues?q=is%3Aopen+is%3A
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.2 <4.0.0'
 
 # Declare that this package only works on Windows.
 platforms:

--- a/packages/windows_security/pubspec.yaml
+++ b/packages/windows_security/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/halildurmus/dartwinrt/issues?q=is%3Aopen+is%3A
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.2 <4.0.0'
 
 # Declare that this package only works on Windows.
 platforms:

--- a/packages/windows_services/pubspec.yaml
+++ b/packages/windows_services/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/halildurmus/dartwinrt/issues?q=is%3Aopen+is%3A
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.2 <4.0.0'
 
 # Declare that this package only works on Windows.
 platforms:

--- a/packages/windows_storage/pubspec.yaml
+++ b/packages/windows_storage/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/halildurmus/dartwinrt/issues?q=is%3Aopen+is%3A
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.2 <4.0.0'
 
 # Declare that this package only works on Windows.
 platforms:

--- a/packages/windows_system/pubspec.yaml
+++ b/packages/windows_system/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/halildurmus/dartwinrt/issues?q=is%3Aopen+is%3A
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.2 <4.0.0'
 
 # Declare that this package only works on Windows.
 platforms:

--- a/packages/windows_ui/pubspec.yaml
+++ b/packages/windows_ui/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/halildurmus/dartwinrt/issues?q=is%3Aopen+is%3A
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.2 <4.0.0'
 
 # Declare that this package only works on Windows.
 platforms:

--- a/packages/windows_web/pubspec.yaml
+++ b/packages/windows_web/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/halildurmus/dartwinrt/issues?q=is%3Aopen+is%3A
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.2 <4.0.0'
 
 # Declare that this package only works on Windows.
 platforms:

--- a/packages/winrtgen/pubspec.yaml
+++ b/packages/winrtgen/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/halildurmus/dartwinrt/issues?q=is%3Aopen+is%3A
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.2 <4.0.0'
 
 # Declare that this package only works on Windows.
 platforms:


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

Bumps Dart SDK lower bound to `>=2.19.2`.

## Related Issue

None

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
