### PR TITLE
Cast objects to appropriate interfaces on `IIterable` parameters

### DIFF
--- a/packages/windows_data/lib/src/json/ijsonarraystatics.dart
+++ b/packages/windows_data/lib/src/json/ijsonarraystatics.dart
@@ -65,6 +65,7 @@ class IJsonArrayStatics extends IInspectable {
   bool tryParse(String input, JsonArray result) {
     final retValuePtr = calloc<Bool>();
     final inputHString = convertToHString(input);
+    final resultPtr = result.ptr;
 
     try {
       final hr = ptr.ref.vtable
@@ -81,7 +82,7 @@ class IJsonArrayStatics extends IInspectable {
               .asFunction<
                   int Function(LPVTBL lpVtbl, int input,
                       Pointer<COMObject> result, Pointer<Bool> retValuePtr)>()(
-          ptr.ref.lpVtbl, inputHString, result.ptr, retValuePtr);
+          ptr.ref.lpVtbl, inputHString, resultPtr, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/packages/windows_data/lib/src/json/ijsonobject.dart
+++ b/packages/windows_data/lib/src/json/ijsonobject.dart
@@ -67,6 +67,7 @@ class IJsonObject extends IInspectable implements IJsonValue {
 
   void setNamedValue(String name, IJsonValue? value) {
     final nameHString = convertToHString(name);
+    final valuePtr = value == null ? nullptr : value.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(7)
@@ -77,9 +78,7 @@ class IJsonObject extends IInspectable implements IJsonValue {
                             LPVTBL lpVtbl, IntPtr name, LPVTBL value)>>>()
             .value
             .asFunction<int Function(LPVTBL lpVtbl, int name, LPVTBL value)>()(
-        ptr.ref.lpVtbl,
-        nameHString,
-        value == null ? nullptr : value.ptr.ref.lpVtbl);
+        ptr.ref.lpVtbl, nameHString, valuePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 

--- a/packages/windows_data/lib/src/json/ijsonobjectstatics.dart
+++ b/packages/windows_data/lib/src/json/ijsonobjectstatics.dart
@@ -65,6 +65,7 @@ class IJsonObjectStatics extends IInspectable {
   bool tryParse(String input, JsonObject result) {
     final retValuePtr = calloc<Bool>();
     final inputHString = convertToHString(input);
+    final resultPtr = result.ptr;
 
     try {
       final hr = ptr.ref.vtable
@@ -81,7 +82,7 @@ class IJsonObjectStatics extends IInspectable {
               .asFunction<
                   int Function(LPVTBL lpVtbl, int input,
                       Pointer<COMObject> result, Pointer<Bool> retValuePtr)>()(
-          ptr.ref.lpVtbl, inputHString, result.ptr, retValuePtr);
+          ptr.ref.lpVtbl, inputHString, resultPtr, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/packages/windows_data/lib/src/json/ijsonobjectwithdefaultvalues.dart
+++ b/packages/windows_data/lib/src/json/ijsonobjectwithdefaultvalues.dart
@@ -40,6 +40,8 @@ class IJsonObjectWithDefaultValues extends IInspectable
   JsonValue? getNamedValueOrDefault(String name, JsonValue? defaultValue) {
     final retValuePtr = calloc<COMObject>();
     final nameHString = convertToHString(name);
+    final defaultValuePtr =
+        defaultValue == null ? nullptr : defaultValue.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(6)
@@ -55,10 +57,7 @@ class IJsonObjectWithDefaultValues extends IInspectable
             .asFunction<
                 int Function(LPVTBL lpVtbl, int name, LPVTBL defaultValue,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        nameHString,
-        defaultValue == null ? nullptr : defaultValue.ptr.ref.lpVtbl,
-        retValuePtr);
+        ptr.ref.lpVtbl, nameHString, defaultValuePtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -78,6 +77,8 @@ class IJsonObjectWithDefaultValues extends IInspectable
   JsonObject? getNamedObjectOrDefault(String name, JsonObject? defaultValue) {
     final retValuePtr = calloc<COMObject>();
     final nameHString = convertToHString(name);
+    final defaultValuePtr =
+        defaultValue == null ? nullptr : defaultValue.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(7)
@@ -93,10 +94,7 @@ class IJsonObjectWithDefaultValues extends IInspectable
             .asFunction<
                 int Function(LPVTBL lpVtbl, int name, LPVTBL defaultValue,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        nameHString,
-        defaultValue == null ? nullptr : defaultValue.ptr.ref.lpVtbl,
-        retValuePtr);
+        ptr.ref.lpVtbl, nameHString, defaultValuePtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -150,6 +148,8 @@ class IJsonObjectWithDefaultValues extends IInspectable
   JsonArray? getNamedArrayOrDefault(String name, JsonArray? defaultValue) {
     final retValuePtr = calloc<COMObject>();
     final nameHString = convertToHString(name);
+    final defaultValuePtr =
+        defaultValue == null ? nullptr : defaultValue.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(9)
@@ -165,10 +165,7 @@ class IJsonObjectWithDefaultValues extends IInspectable
             .asFunction<
                 int Function(LPVTBL lpVtbl, int name, LPVTBL defaultValue,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        nameHString,
-        defaultValue == null ? nullptr : defaultValue.ptr.ref.lpVtbl,
-        retValuePtr);
+        ptr.ref.lpVtbl, nameHString, defaultValuePtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_data/lib/src/json/ijsonvaluestatics.dart
+++ b/packages/windows_data/lib/src/json/ijsonvaluestatics.dart
@@ -65,6 +65,7 @@ class IJsonValueStatics extends IInspectable {
   bool tryParse(String input, JsonValue result) {
     final retValuePtr = calloc<Bool>();
     final inputHString = convertToHString(input);
+    final resultPtr = result.ptr;
 
     try {
       final hr = ptr.ref.vtable
@@ -81,7 +82,7 @@ class IJsonValueStatics extends IInspectable {
               .asFunction<
                   int Function(LPVTBL lpVtbl, int input,
                       Pointer<COMObject> result, Pointer<Bool> retValuePtr)>()(
-          ptr.ref.lpVtbl, inputHString, result.ptr, retValuePtr);
+          ptr.ref.lpVtbl, inputHString, resultPtr, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/packages/windows_data/lib/src/xml/dom/ixmldocument.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmldocument.dart
@@ -445,7 +445,7 @@ class IXmlDocument extends IInspectable
 
   XmlAttribute? createAttributeNS(Object? namespaceUri, String qualifiedName) {
     final retValuePtr = calloc<COMObject>();
-
+    final namespaceUriPtr = namespaceUri?.intoBox().ref.lpVtbl ?? nullptr;
     final qualifiedNameHString = convertToHString(qualifiedName);
 
     final hr = ptr.ref.vtable
@@ -462,10 +462,7 @@ class IXmlDocument extends IInspectable
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL namespaceUri,
                     int qualifiedName, Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        namespaceUri?.intoBox().ref.lpVtbl ?? nullptr,
-        qualifiedNameHString,
-        retValuePtr);
+        ptr.ref.lpVtbl, namespaceUriPtr, qualifiedNameHString, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -484,7 +481,7 @@ class IXmlDocument extends IInspectable
 
   XmlElement? createElementNS(Object? namespaceUri, String qualifiedName) {
     final retValuePtr = calloc<COMObject>();
-
+    final namespaceUriPtr = namespaceUri?.intoBox().ref.lpVtbl ?? nullptr;
     final qualifiedNameHString = convertToHString(qualifiedName);
 
     final hr = ptr.ref.vtable
@@ -501,10 +498,7 @@ class IXmlDocument extends IInspectable
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL namespaceUri,
                     int qualifiedName, Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        namespaceUri?.intoBox().ref.lpVtbl ?? nullptr,
-        qualifiedNameHString,
-        retValuePtr);
+        ptr.ref.lpVtbl, namespaceUriPtr, qualifiedNameHString, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -555,6 +549,7 @@ class IXmlDocument extends IInspectable
 
   IXmlNode? importNode(IXmlNode? node, bool deep) {
     final retValuePtr = calloc<COMObject>();
+    final nodePtr = node == null ? nullptr : node.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(22)
@@ -566,8 +561,8 @@ class IXmlDocument extends IInspectable
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL node, bool deep,
-                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
-        node == null ? nullptr : node.ptr.ref.lpVtbl, deep, retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(
+        ptr.ref.lpVtbl, nodePtr, deep, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_data/lib/src/xml/dom/ixmldocumentio.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmldocumentio.dart
@@ -49,6 +49,8 @@ class IXmlDocumentIO extends IInspectable {
 
   void loadXmlWithSettings(String xml, XmlLoadSettings? loadSettings) {
     final xmlHString = convertToHString(xml);
+    final loadSettingsPtr =
+        loadSettings == null ? nullptr : loadSettings.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(7)
@@ -60,9 +62,7 @@ class IXmlDocumentIO extends IInspectable {
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, int xml, LPVTBL loadSettings)>()(
-        ptr.ref.lpVtbl,
-        xmlHString,
-        loadSettings == null ? nullptr : loadSettings.ptr.ref.lpVtbl);
+        ptr.ref.lpVtbl, xmlHString, loadSettingsPtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -72,6 +72,7 @@ class IXmlDocumentIO extends IInspectable {
   Future<void> saveToFileAsync(IStorageFile? file) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<void>();
+    final filePtr = file == null ? nullptr : file.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(8)
@@ -83,8 +84,8 @@ class IXmlDocumentIO extends IInspectable {
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL file,
-                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
-        file == null ? nullptr : file.ptr.ref.lpVtbl, retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(
+        ptr.ref.lpVtbl, filePtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_data/lib/src/xml/dom/ixmldocumentio2.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmldocumentio2.dart
@@ -32,6 +32,8 @@ class IXmlDocumentIO2 extends IInspectable {
           interface.toInterface(IID_IXmlDocumentIO2));
 
   void loadXmlFromBuffer(IBuffer? buffer) {
+    final bufferPtr = buffer == null ? nullptr : buffer.ptr.ref.lpVtbl;
+
     final hr = ptr.ref.vtable
             .elementAt(6)
             .cast<
@@ -40,13 +42,17 @@ class IXmlDocumentIO2 extends IInspectable {
                         HRESULT Function(LPVTBL lpVtbl, LPVTBL buffer)>>>()
             .value
             .asFunction<int Function(LPVTBL lpVtbl, LPVTBL buffer)>()(
-        ptr.ref.lpVtbl, buffer == null ? nullptr : buffer.ptr.ref.lpVtbl);
+        ptr.ref.lpVtbl, bufferPtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void loadXmlFromBufferWithSettings(
       IBuffer? buffer, XmlLoadSettings? loadSettings) {
+    final bufferPtr = buffer == null ? nullptr : buffer.ptr.ref.lpVtbl;
+    final loadSettingsPtr =
+        loadSettings == null ? nullptr : loadSettings.ptr.ref.lpVtbl;
+
     final hr = ptr.ref.vtable
             .elementAt(7)
             .cast<
@@ -58,9 +64,7 @@ class IXmlDocumentIO2 extends IInspectable {
             .asFunction<
                 int Function(
                     LPVTBL lpVtbl, LPVTBL buffer, LPVTBL loadSettings)>()(
-        ptr.ref.lpVtbl,
-        buffer == null ? nullptr : buffer.ptr.ref.lpVtbl,
-        loadSettings == null ? nullptr : loadSettings.ptr.ref.lpVtbl);
+        ptr.ref.lpVtbl, bufferPtr, loadSettingsPtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/packages/windows_data/lib/src/xml/dom/ixmldocumentstatics.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmldocumentstatics.dart
@@ -72,6 +72,8 @@ class IXmlDocumentStatics extends IInspectable {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<XmlDocument?>();
     final uriUri = uri == null ? null : winrt_uri.Uri.createUri(uri.toString());
+    final loadSettingsPtr =
+        loadSettings == null ? nullptr : loadSettings.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(7)
@@ -89,7 +91,7 @@ class IXmlDocumentStatics extends IInspectable {
                     Pointer<COMObject> retValuePtr)>()(
         ptr.ref.lpVtbl,
         uriUri == null ? nullptr : uriUri.ptr.ref.lpVtbl,
-        loadSettings == null ? nullptr : loadSettings.ptr.ref.lpVtbl,
+        loadSettingsPtr,
         retValuePtr);
 
     if (FAILED(hr)) {
@@ -111,6 +113,7 @@ class IXmlDocumentStatics extends IInspectable {
   Future<XmlDocument?> loadFromFileAsync(IStorageFile? file) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<XmlDocument?>();
+    final filePtr = file == null ? nullptr : file.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(8)
@@ -122,8 +125,8 @@ class IXmlDocumentStatics extends IInspectable {
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL file,
-                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
-        file == null ? nullptr : file.ptr.ref.lpVtbl, retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(
+        ptr.ref.lpVtbl, filePtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -143,6 +146,9 @@ class IXmlDocumentStatics extends IInspectable {
       IStorageFile? file, XmlLoadSettings? loadSettings) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<XmlDocument?>();
+    final filePtr = file == null ? nullptr : file.ptr.ref.lpVtbl;
+    final loadSettingsPtr =
+        loadSettings == null ? nullptr : loadSettings.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(9)
@@ -158,10 +164,7 @@ class IXmlDocumentStatics extends IInspectable {
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL file, LPVTBL loadSettings,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        file == null ? nullptr : file.ptr.ref.lpVtbl,
-        loadSettings == null ? nullptr : loadSettings.ptr.ref.lpVtbl,
-        retValuePtr);
+        ptr.ref.lpVtbl, filePtr, loadSettingsPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_data/lib/src/xml/dom/ixmldomimplementation.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmldomimplementation.dart
@@ -31,6 +31,7 @@ class IXmlDomImplementation extends IInspectable {
   bool hasFeature(String feature, Object? version) {
     final retValuePtr = calloc<Bool>();
     final featureHString = convertToHString(feature);
+    final versionPtr = version?.intoBox().ref.lpVtbl ?? nullptr;
 
     try {
       final hr = ptr.ref.vtable
@@ -44,10 +45,7 @@ class IXmlDomImplementation extends IInspectable {
               .asFunction<
                   int Function(LPVTBL lpVtbl, int feature, LPVTBL version,
                       Pointer<Bool> retValuePtr)>()(
-          ptr.ref.lpVtbl,
-          featureHString,
-          version?.intoBox().ref.lpVtbl ?? nullptr,
-          retValuePtr);
+          ptr.ref.lpVtbl, featureHString, versionPtr, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/packages/windows_data/lib/src/xml/dom/ixmlelement.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmlelement.dart
@@ -167,6 +167,8 @@ class IXmlElement extends IInspectable
 
   XmlAttribute? setAttributeNode(XmlAttribute? newAttribute) {
     final retValuePtr = calloc<COMObject>();
+    final newAttributePtr =
+        newAttribute == null ? nullptr : newAttribute.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(11)
@@ -179,9 +181,7 @@ class IXmlElement extends IInspectable
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL newAttribute,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        newAttribute == null ? nullptr : newAttribute.ptr.ref.lpVtbl,
-        retValuePtr);
+        ptr.ref.lpVtbl, newAttributePtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -198,6 +198,8 @@ class IXmlElement extends IInspectable
 
   XmlAttribute? removeAttributeNode(XmlAttribute? attributeNode) {
     final retValuePtr = calloc<COMObject>();
+    final attributeNodePtr =
+        attributeNode == null ? nullptr : attributeNode.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(12)
@@ -210,9 +212,7 @@ class IXmlElement extends IInspectable
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL attributeNode,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        attributeNode == null ? nullptr : attributeNode.ptr.ref.lpVtbl,
-        retValuePtr);
+        ptr.ref.lpVtbl, attributeNodePtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -261,6 +261,7 @@ class IXmlElement extends IInspectable
 
   void setAttributeNS(
       Object? namespaceUri, String qualifiedName, String value) {
+    final namespaceUriPtr = namespaceUri?.intoBox().ref.lpVtbl ?? nullptr;
     final qualifiedNameHString = convertToHString(qualifiedName);
     final valueHString = convertToHString(value);
 
@@ -275,10 +276,7 @@ class IXmlElement extends IInspectable
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL namespaceUri,
                     int qualifiedName, int value)>()(
-        ptr.ref.lpVtbl,
-        namespaceUri?.intoBox().ref.lpVtbl ?? nullptr,
-        qualifiedNameHString,
-        valueHString);
+        ptr.ref.lpVtbl, namespaceUriPtr, qualifiedNameHString, valueHString);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -288,7 +286,7 @@ class IXmlElement extends IInspectable
 
   String getAttributeNS(Object? namespaceUri, String localName) {
     final retValuePtr = calloc<HSTRING>();
-
+    final namespaceUriPtr = namespaceUri?.intoBox().ref.lpVtbl ?? nullptr;
     final localNameHString = convertToHString(localName);
 
     try {
@@ -307,10 +305,7 @@ class IXmlElement extends IInspectable
                   .asFunction<
                       int Function(LPVTBL lpVtbl, LPVTBL namespaceUri,
                           int localName, Pointer<IntPtr> retValuePtr)>()(
-              ptr.ref.lpVtbl,
-              namespaceUri?.intoBox().ref.lpVtbl ?? nullptr,
-              localNameHString,
-              retValuePtr);
+              ptr.ref.lpVtbl, namespaceUriPtr, localNameHString, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -323,6 +318,7 @@ class IXmlElement extends IInspectable
   }
 
   void removeAttributeNS(Object? namespaceUri, String localName) {
+    final namespaceUriPtr = namespaceUri?.intoBox().ref.lpVtbl ?? nullptr;
     final localNameHString = convertToHString(localName);
 
     final hr = ptr.ref.vtable
@@ -336,9 +332,7 @@ class IXmlElement extends IInspectable
             .asFunction<
                 int Function(
                     LPVTBL lpVtbl, LPVTBL namespaceUri, int localName)>()(
-        ptr.ref.lpVtbl,
-        namespaceUri?.intoBox().ref.lpVtbl ?? nullptr,
-        localNameHString);
+        ptr.ref.lpVtbl, namespaceUriPtr, localNameHString);
 
     if (FAILED(hr)) throw WindowsException(hr);
 
@@ -347,6 +341,8 @@ class IXmlElement extends IInspectable
 
   XmlAttribute? setAttributeNodeNS(XmlAttribute? newAttribute) {
     final retValuePtr = calloc<COMObject>();
+    final newAttributePtr =
+        newAttribute == null ? nullptr : newAttribute.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(17)
@@ -359,9 +355,7 @@ class IXmlElement extends IInspectable
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL newAttribute,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        newAttribute == null ? nullptr : newAttribute.ptr.ref.lpVtbl,
-        retValuePtr);
+        ptr.ref.lpVtbl, newAttributePtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -378,7 +372,7 @@ class IXmlElement extends IInspectable
 
   XmlAttribute? getAttributeNodeNS(Object? namespaceUri, String localName) {
     final retValuePtr = calloc<COMObject>();
-
+    final namespaceUriPtr = namespaceUri?.intoBox().ref.lpVtbl ?? nullptr;
     final localNameHString = convertToHString(localName);
 
     final hr =
@@ -396,10 +390,7 @@ class IXmlElement extends IInspectable
                 .asFunction<
                     int Function(LPVTBL lpVtbl, LPVTBL namespaceUri,
                         int localName, Pointer<COMObject> retValuePtr)>()(
-            ptr.ref.lpVtbl,
-            namespaceUri?.intoBox().ref.lpVtbl ?? nullptr,
-            localNameHString,
-            retValuePtr);
+            ptr.ref.lpVtbl, namespaceUriPtr, localNameHString, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_data/lib/src/xml/dom/ixmlnamednodemap.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmlnamednodemap.dart
@@ -118,6 +118,7 @@ class IXmlNamedNodeMap extends IInspectable
 
   IXmlNode? setNamedItem(IXmlNode? node) {
     final retValuePtr = calloc<COMObject>();
+    final nodePtr = node == null ? nullptr : node.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(9)
@@ -129,8 +130,8 @@ class IXmlNamedNodeMap extends IInspectable
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL node,
-                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
-        node == null ? nullptr : node.ptr.ref.lpVtbl, retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(
+        ptr.ref.lpVtbl, nodePtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -179,7 +180,7 @@ class IXmlNamedNodeMap extends IInspectable
 
   IXmlNode? getNamedItemNS(Object? namespaceUri, String name) {
     final retValuePtr = calloc<COMObject>();
-
+    final namespaceUriPtr = namespaceUri?.intoBox().ref.lpVtbl ?? nullptr;
     final nameHString = convertToHString(name);
 
     final hr = ptr.ref.vtable
@@ -193,10 +194,7 @@ class IXmlNamedNodeMap extends IInspectable
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL namespaceUri, int name,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        namespaceUri?.intoBox().ref.lpVtbl ?? nullptr,
-        nameHString,
-        retValuePtr);
+        ptr.ref.lpVtbl, namespaceUriPtr, nameHString, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -215,7 +213,7 @@ class IXmlNamedNodeMap extends IInspectable
 
   IXmlNode? removeNamedItemNS(Object? namespaceUri, String name) {
     final retValuePtr = calloc<COMObject>();
-
+    final namespaceUriPtr = namespaceUri?.intoBox().ref.lpVtbl ?? nullptr;
     final nameHString = convertToHString(name);
 
     final hr = ptr.ref.vtable
@@ -229,10 +227,7 @@ class IXmlNamedNodeMap extends IInspectable
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL namespaceUri, int name,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        namespaceUri?.intoBox().ref.lpVtbl ?? nullptr,
-        nameHString,
-        retValuePtr);
+        ptr.ref.lpVtbl, namespaceUriPtr, nameHString, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -251,6 +246,7 @@ class IXmlNamedNodeMap extends IInspectable
 
   IXmlNode? setNamedItemNS(IXmlNode? node) {
     final retValuePtr = calloc<COMObject>();
+    final nodePtr = node == null ? nullptr : node.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(13)
@@ -262,8 +258,8 @@ class IXmlNamedNodeMap extends IInspectable
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL node,
-                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
-        node == null ? nullptr : node.ptr.ref.lpVtbl, retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(
+        ptr.ref.lpVtbl, nodePtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_data/lib/src/xml/dom/ixmlnode.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmlnode.dart
@@ -382,6 +382,9 @@ class IXmlNode extends IInspectable
 
   IXmlNode? insertBefore(IXmlNode? newChild, IXmlNode? referenceChild) {
     final retValuePtr = calloc<COMObject>();
+    final newChildPtr = newChild == null ? nullptr : newChild.ptr.ref.lpVtbl;
+    final referenceChildPtr =
+        referenceChild == null ? nullptr : referenceChild.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(19)
@@ -397,10 +400,7 @@ class IXmlNode extends IInspectable
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL newChild,
                     LPVTBL referenceChild, Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        newChild == null ? nullptr : newChild.ptr.ref.lpVtbl,
-        referenceChild == null ? nullptr : referenceChild.ptr.ref.lpVtbl,
-        retValuePtr);
+        ptr.ref.lpVtbl, newChildPtr, referenceChildPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -417,6 +417,9 @@ class IXmlNode extends IInspectable
 
   IXmlNode? replaceChild(IXmlNode? newChild, IXmlNode? referenceChild) {
     final retValuePtr = calloc<COMObject>();
+    final newChildPtr = newChild == null ? nullptr : newChild.ptr.ref.lpVtbl;
+    final referenceChildPtr =
+        referenceChild == null ? nullptr : referenceChild.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(20)
@@ -432,10 +435,7 @@ class IXmlNode extends IInspectable
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL newChild,
                     LPVTBL referenceChild, Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        newChild == null ? nullptr : newChild.ptr.ref.lpVtbl,
-        referenceChild == null ? nullptr : referenceChild.ptr.ref.lpVtbl,
-        retValuePtr);
+        ptr.ref.lpVtbl, newChildPtr, referenceChildPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -452,6 +452,7 @@ class IXmlNode extends IInspectable
 
   IXmlNode? removeChild(IXmlNode? childNode) {
     final retValuePtr = calloc<COMObject>();
+    final childNodePtr = childNode == null ? nullptr : childNode.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(21)
@@ -463,8 +464,8 @@ class IXmlNode extends IInspectable
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL childNode,
-                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
-        childNode == null ? nullptr : childNode.ptr.ref.lpVtbl, retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(
+        ptr.ref.lpVtbl, childNodePtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -481,6 +482,7 @@ class IXmlNode extends IInspectable
 
   IXmlNode? appendChild(IXmlNode? newChild) {
     final retValuePtr = calloc<COMObject>();
+    final newChildPtr = newChild == null ? nullptr : newChild.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(22)
@@ -492,8 +494,8 @@ class IXmlNode extends IInspectable
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL newChild,
-                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
-        newChild == null ? nullptr : newChild.ptr.ref.lpVtbl, retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(
+        ptr.ref.lpVtbl, newChildPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_data/lib/src/xml/dom/ixmlnodeselector.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmlnodeselector.dart
@@ -98,6 +98,7 @@ class IXmlNodeSelector extends IInspectable {
   IXmlNode? selectSingleNodeNS(String xpath, Object? namespaces) {
     final retValuePtr = calloc<COMObject>();
     final xpathHString = convertToHString(xpath);
+    final namespacesPtr = namespaces?.intoBox().ref.lpVtbl ?? nullptr;
 
     final hr =
         ptr.ref.vtable
@@ -114,10 +115,7 @@ class IXmlNodeSelector extends IInspectable {
                 .asFunction<
                     int Function(LPVTBL lpVtbl, int xpath, LPVTBL namespaces,
                         Pointer<COMObject> retValuePtr)>()(
-            ptr.ref.lpVtbl,
-            xpathHString,
-            namespaces?.intoBox().ref.lpVtbl ?? nullptr,
-            retValuePtr);
+            ptr.ref.lpVtbl, xpathHString, namespacesPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -137,6 +135,7 @@ class IXmlNodeSelector extends IInspectable {
   XmlNodeList? selectNodesNS(String xpath, Object? namespaces) {
     final retValuePtr = calloc<COMObject>();
     final xpathHString = convertToHString(xpath);
+    final namespacesPtr = namespaces?.intoBox().ref.lpVtbl ?? nullptr;
 
     final hr =
         ptr.ref.vtable
@@ -153,10 +152,7 @@ class IXmlNodeSelector extends IInspectable {
                 .asFunction<
                     int Function(LPVTBL lpVtbl, int xpath, LPVTBL namespaces,
                         Pointer<COMObject> retValuePtr)>()(
-            ptr.ref.lpVtbl,
-            xpathHString,
-            namespaces?.intoBox().ref.lpVtbl ?? nullptr,
-            retValuePtr);
+            ptr.ref.lpVtbl, xpathHString, namespacesPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_devices/lib/src/enumeration/ideviceinformation.dart
+++ b/packages/windows_devices/lib/src/enumeration/ideviceinformation.dart
@@ -187,6 +187,9 @@ class IDeviceInformation extends IInspectable {
   }
 
   void update(DeviceInformationUpdate? updateInfo) {
+    final updateInfoPtr =
+        updateInfo == null ? nullptr : updateInfo.ptr.ref.lpVtbl;
+
     final hr = ptr.ref.vtable
             .elementAt(12)
             .cast<
@@ -195,8 +198,7 @@ class IDeviceInformation extends IInspectable {
                         HRESULT Function(LPVTBL lpVtbl, LPVTBL updateInfo)>>>()
             .value
             .asFunction<int Function(LPVTBL lpVtbl, LPVTBL updateInfo)>()(
-        ptr.ref.lpVtbl,
-        updateInfo == null ? nullptr : updateInfo.ptr.ref.lpVtbl);
+        ptr.ref.lpVtbl, updateInfoPtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/packages/windows_devices/lib/src/enumeration/ideviceinformationcustompairing.dart
+++ b/packages/windows_devices/lib/src/enumeration/ideviceinformationcustompairing.dart
@@ -114,6 +114,10 @@ class IDeviceInformationCustomPairing extends IInspectable {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<DevicePairingResult?>();
 
+    final devicePairingSettingsPtr = devicePairingSettings == null
+        ? nullptr
+        : devicePairingSettings.ptr.ref.lpVtbl;
+
     final hr = ptr.ref.vtable
             .elementAt(8)
             .cast<
@@ -136,9 +140,7 @@ class IDeviceInformationCustomPairing extends IInspectable {
         ptr.ref.lpVtbl,
         pairingKindsSupported.value,
         minProtectionLevel.value,
-        devicePairingSettings == null
-            ? nullptr
-            : devicePairingSettings.ptr.ref.lpVtbl,
+        devicePairingSettingsPtr,
         retValuePtr);
 
     if (FAILED(hr)) {

--- a/packages/windows_devices/lib/src/enumeration/ideviceinformationpairing2.dart
+++ b/packages/windows_devices/lib/src/enumeration/ideviceinformationpairing2.dart
@@ -92,6 +92,10 @@ class IDeviceInformationPairing2 extends IInspectable {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<DevicePairingResult?>();
 
+    final devicePairingSettingsPtr = devicePairingSettings == null
+        ? nullptr
+        : devicePairingSettings.ptr.ref.lpVtbl;
+
     final hr = ptr.ref.vtable
             .elementAt(8)
             .cast<
@@ -108,13 +112,8 @@ class IDeviceInformationPairing2 extends IInspectable {
                     LPVTBL lpVtbl,
                     int minProtectionLevel,
                     LPVTBL devicePairingSettings,
-                    Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        minProtectionLevel.value,
-        devicePairingSettings == null
-            ? nullptr
-            : devicePairingSettings.ptr.ref.lpVtbl,
-        retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
+        minProtectionLevel.value, devicePairingSettingsPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_devices/lib/src/enumeration/ideviceinformationstatics.dart
+++ b/packages/windows_devices/lib/src/enumeration/ideviceinformationstatics.dart
@@ -72,6 +72,13 @@ class IDeviceInformationStatics extends IInspectable {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<DeviceInformation?>();
     final deviceIdHString = convertToHString(deviceId);
+    final additionalPropertiesPtr = additionalProperties == null
+        ? nullptr
+        : IInspectable(additionalProperties
+                .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+            .ptr
+            .ref
+            .lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(7)
@@ -90,12 +97,7 @@ class IDeviceInformationStatics extends IInspectable {
                     int deviceId,
                     LPVTBL additionalProperties,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        deviceIdHString,
-        additionalProperties == null
-            ? nullptr
-            : additionalProperties.ptr.ref.lpVtbl,
-        retValuePtr);
+        ptr.ref.lpVtbl, deviceIdHString, additionalPropertiesPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -103,6 +105,7 @@ class IDeviceInformationStatics extends IInspectable {
     }
 
     WindowsDeleteString(deviceIdHString);
+    additionalProperties?.release();
 
     final asyncOperation = IAsyncOperation<DeviceInformation?>.fromRawPointer(
         retValuePtr,
@@ -218,6 +221,13 @@ class IDeviceInformationStatics extends IInspectable {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<DeviceInformationCollection?>();
     final aqsFilterHString = convertToHString(aqsFilter);
+    final additionalPropertiesPtr = additionalProperties == null
+        ? nullptr
+        : IInspectable(additionalProperties
+                .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+            .ptr
+            .ref
+            .lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(11)
@@ -236,12 +246,7 @@ class IDeviceInformationStatics extends IInspectable {
                     int aqsFilter,
                     LPVTBL additionalProperties,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        aqsFilterHString,
-        additionalProperties == null
-            ? nullptr
-            : additionalProperties.ptr.ref.lpVtbl,
-        retValuePtr);
+        ptr.ref.lpVtbl, aqsFilterHString, additionalPropertiesPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -249,6 +254,7 @@ class IDeviceInformationStatics extends IInspectable {
     }
 
     WindowsDeleteString(aqsFilterHString);
+    additionalProperties?.release();
 
     final asyncOperation =
         IAsyncOperation<DeviceInformationCollection?>.fromRawPointer(
@@ -353,6 +359,13 @@ class IDeviceInformationStatics extends IInspectable {
       String aqsFilter, IIterable<String>? additionalProperties) {
     final retValuePtr = calloc<COMObject>();
     final aqsFilterHString = convertToHString(aqsFilter);
+    final additionalPropertiesPtr = additionalProperties == null
+        ? nullptr
+        : IInspectable(additionalProperties
+                .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+            .ptr
+            .ref
+            .lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(15)
@@ -371,12 +384,7 @@ class IDeviceInformationStatics extends IInspectable {
                     int aqsFilter,
                     LPVTBL additionalProperties,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        aqsFilterHString,
-        additionalProperties == null
-            ? nullptr
-            : additionalProperties.ptr.ref.lpVtbl,
-        retValuePtr);
+        ptr.ref.lpVtbl, aqsFilterHString, additionalPropertiesPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -384,6 +392,7 @@ class IDeviceInformationStatics extends IInspectable {
     }
 
     WindowsDeleteString(aqsFilterHString);
+    additionalProperties?.release();
 
     if (retValuePtr.ref.isNull) {
       free(retValuePtr);

--- a/packages/windows_devices/lib/src/enumeration/ideviceinformationstatics2.dart
+++ b/packages/windows_devices/lib/src/enumeration/ideviceinformationstatics2.dart
@@ -66,6 +66,13 @@ class IDeviceInformationStatics2 extends IInspectable {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<DeviceInformation?>();
     final deviceIdHString = convertToHString(deviceId);
+    final additionalPropertiesPtr = additionalProperties == null
+        ? nullptr
+        : IInspectable(additionalProperties
+                .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+            .ptr
+            .ref
+            .lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(7)
@@ -85,14 +92,8 @@ class IDeviceInformationStatics2 extends IInspectable {
                     int deviceId,
                     LPVTBL additionalProperties,
                     int kind,
-                    Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        deviceIdHString,
-        additionalProperties == null
-            ? nullptr
-            : additionalProperties.ptr.ref.lpVtbl,
-        kind.value,
-        retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
+        deviceIdHString, additionalPropertiesPtr, kind.value, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -100,6 +101,7 @@ class IDeviceInformationStatics2 extends IInspectable {
     }
 
     WindowsDeleteString(deviceIdHString);
+    additionalProperties?.release();
 
     final asyncOperation = IAsyncOperation<DeviceInformation?>.fromRawPointer(
         retValuePtr,
@@ -116,6 +118,13 @@ class IDeviceInformationStatics2 extends IInspectable {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<DeviceInformationCollection?>();
     final aqsFilterHString = convertToHString(aqsFilter);
+    final additionalPropertiesPtr = additionalProperties == null
+        ? nullptr
+        : IInspectable(additionalProperties
+                .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+            .ptr
+            .ref
+            .lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(8)
@@ -135,14 +144,8 @@ class IDeviceInformationStatics2 extends IInspectable {
                     int aqsFilter,
                     LPVTBL additionalProperties,
                     int kind,
-                    Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        aqsFilterHString,
-        additionalProperties == null
-            ? nullptr
-            : additionalProperties.ptr.ref.lpVtbl,
-        kind.value,
-        retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
+        aqsFilterHString, additionalPropertiesPtr, kind.value, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -150,6 +153,7 @@ class IDeviceInformationStatics2 extends IInspectable {
     }
 
     WindowsDeleteString(aqsFilterHString);
+    additionalProperties?.release();
 
     final asyncOperation =
         IAsyncOperation<DeviceInformationCollection?>.fromRawPointer(
@@ -167,6 +171,13 @@ class IDeviceInformationStatics2 extends IInspectable {
       DeviceInformationKind kind) {
     final retValuePtr = calloc<COMObject>();
     final aqsFilterHString = convertToHString(aqsFilter);
+    final additionalPropertiesPtr = additionalProperties == null
+        ? nullptr
+        : IInspectable(additionalProperties
+                .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+            .ptr
+            .ref
+            .lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(9)
@@ -186,14 +197,8 @@ class IDeviceInformationStatics2 extends IInspectable {
                     int aqsFilter,
                     LPVTBL additionalProperties,
                     int kind,
-                    Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        aqsFilterHString,
-        additionalProperties == null
-            ? nullptr
-            : additionalProperties.ptr.ref.lpVtbl,
-        kind.value,
-        retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
+        aqsFilterHString, additionalPropertiesPtr, kind.value, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -201,6 +206,7 @@ class IDeviceInformationStatics2 extends IInspectable {
     }
 
     WindowsDeleteString(aqsFilterHString);
+    additionalProperties?.release();
 
     if (retValuePtr.ref.isNull) {
       free(retValuePtr);

--- a/packages/windows_devices/lib/src/enumeration/idevicepicker.dart
+++ b/packages/windows_devices/lib/src/enumeration/idevicepicker.dart
@@ -340,6 +340,7 @@ class IDevicePicker extends IInspectable {
 
   void setDisplayStatus(DeviceInformation? device, String status,
       DevicePickerDisplayStatusOptions options) {
+    final devicePtr = device == null ? nullptr : device.ptr.ref.lpVtbl;
     final statusHString = convertToHString(status);
 
     final hr = ptr.ref.vtable
@@ -353,10 +354,7 @@ class IDevicePicker extends IInspectable {
             .asFunction<
                 int Function(
                     LPVTBL lpVtbl, LPVTBL device, int status, int options)>()(
-        ptr.ref.lpVtbl,
-        device == null ? nullptr : device.ptr.ref.lpVtbl,
-        statusHString,
-        options.value);
+        ptr.ref.lpVtbl, devicePtr, statusHString, options.value);
 
     if (FAILED(hr)) throw WindowsException(hr);
 

--- a/packages/windows_devices/lib/src/enumeration/idevicewatcher2.dart
+++ b/packages/windows_devices/lib/src/enumeration/idevicewatcher2.dart
@@ -34,6 +34,13 @@ class IDeviceWatcher2 extends IInspectable {
   DeviceWatcherTrigger? getBackgroundTrigger(
       IIterable<DeviceWatcherEventKind>? requestedEventKinds) {
     final retValuePtr = calloc<COMObject>();
+    final requestedEventKindsPtr = requestedEventKinds == null
+        ? nullptr
+        : IInspectable(requestedEventKinds
+                .toInterface('{f04365ab-d3f3-5f85-a7da-dc19cff73d86}'))
+            .ptr
+            .ref
+            .lpVtbl;
 
     final hr =
         ptr.ref.vtable
@@ -49,16 +56,14 @@ class IDeviceWatcher2 extends IInspectable {
                 .asFunction<
                     int Function(LPVTBL lpVtbl, LPVTBL requestedEventKinds,
                         Pointer<COMObject> retValuePtr)>()(
-            ptr.ref.lpVtbl,
-            requestedEventKinds == null
-                ? nullptr
-                : requestedEventKinds.ptr.ref.lpVtbl,
-            retValuePtr);
+            ptr.ref.lpVtbl, requestedEventKindsPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
     }
+
+    requestedEventKinds?.release();
 
     if (retValuePtr.ref.isNull) {
       free(retValuePtr);

--- a/packages/windows_foundation/lib/src/collections/imap_part.dart
+++ b/packages/windows_foundation/lib/src/collections/imap_part.dart
@@ -196,6 +196,7 @@ class _IMapGuidObject extends IMap<Guid, Object?> {
   bool insert(Guid key, Object? value) {
     final retValuePtr = calloc<Bool>();
     final keyNativeGuidPtr = key.toNativeGUID();
+    final valuePtr = value?.intoBox().ref.lpVtbl ?? nullptr;
 
     try {
       final hr =
@@ -210,10 +211,7 @@ class _IMapGuidObject extends IMap<Guid, Object?> {
                   .asFunction<
                       int Function(LPVTBL lpVtbl, GUID key, LPVTBL value,
                           Pointer<Bool> retValuePtr)>()(
-              ptr.ref.lpVtbl,
-              keyNativeGuidPtr.ref,
-              value?.intoBox().ref.lpVtbl ?? nullptr,
-              retValuePtr);
+              ptr.ref.lpVtbl, keyNativeGuidPtr.ref, valuePtr, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -733,6 +731,7 @@ class _IMapStringObject extends IMap<String, Object?> {
   bool insert(String key, Object? value) {
     final retValuePtr = calloc<Bool>();
     final keyHString = convertToHString(key);
+    final valuePtr = value?.intoBox().ref.lpVtbl ?? nullptr;
 
     try {
       final hr =
@@ -746,8 +745,8 @@ class _IMapStringObject extends IMap<String, Object?> {
                   .value
                   .asFunction<
                       int Function(LPVTBL lpVtbl, int key, LPVTBL value,
-                          Pointer<Bool> retValuePtr)>()(ptr.ref.lpVtbl,
-              keyHString, value?.intoBox().ref.lpVtbl ?? nullptr, retValuePtr);
+                          Pointer<Bool> retValuePtr)>()(
+              ptr.ref.lpVtbl, keyHString, valuePtr, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/packages/windows_foundation/lib/src/ipropertyvaluestatics.dart
+++ b/packages/windows_foundation/lib/src/ipropertyvaluestatics.dart
@@ -348,6 +348,7 @@ class IPropertyValueStatics extends IInspectable {
 
   Pointer<COMObject> createInspectable(Object? value) {
     final retValuePtr = calloc<COMObject>();
+    final valuePtr = value?.intoBox().ref.lpVtbl ?? nullptr;
 
     final hr = ptr.ref.vtable
             .elementAt(19)
@@ -360,7 +361,7 @@ class IPropertyValueStatics extends IInspectable {
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL value,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl, value?.intoBox().ref.lpVtbl ?? nullptr, retValuePtr);
+        ptr.ref.lpVtbl, valuePtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_gaming/lib/src/input/igamepadstatics2.dart
+++ b/packages/windows_gaming/lib/src/input/igamepadstatics2.dart
@@ -34,6 +34,8 @@ class IGamepadStatics2 extends IInspectable implements IGamepadStatics {
 
   Gamepad? fromGameController(IGameController? gameController) {
     final retValuePtr = calloc<COMObject>();
+    final gameControllerPtr =
+        gameController == null ? nullptr : gameController.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(6)
@@ -46,9 +48,7 @@ class IGamepadStatics2 extends IInspectable implements IGamepadStatics {
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL gameController,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        gameController == null ? nullptr : gameController.ptr.ref.lpVtbl,
-        retValuePtr);
+        ptr.ref.lpVtbl, gameControllerPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_globalization/lib/src/icalendar.dart
+++ b/packages/windows_globalization/lib/src/icalendar.dart
@@ -1904,6 +1904,7 @@ class ICalendar extends IInspectable {
 
   int compare(Calendar? other) {
     final retValuePtr = calloc<Int32>();
+    final otherPtr = other == null ? nullptr : other.ptr.ref.lpVtbl;
 
     try {
       final hr = ptr.ref.vtable
@@ -1916,8 +1917,8 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(LPVTBL lpVtbl, LPVTBL other,
-                      Pointer<Int32> retValuePtr)>()(ptr.ref.lpVtbl,
-          other == null ? nullptr : other.ptr.ref.lpVtbl, retValuePtr);
+                      Pointer<Int32> retValuePtr)>()(
+          ptr.ref.lpVtbl, otherPtr, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1955,6 +1956,8 @@ class ICalendar extends IInspectable {
   }
 
   void copyTo(Calendar? other) {
+    final otherPtr = other == null ? nullptr : other.ptr.ref.lpVtbl;
+
     final hr = ptr.ref.vtable
             .elementAt(95)
             .cast<
@@ -1963,7 +1966,7 @@ class ICalendar extends IInspectable {
                         HRESULT Function(LPVTBL lpVtbl, LPVTBL other)>>>()
             .value
             .asFunction<int Function(LPVTBL lpVtbl, LPVTBL other)>()(
-        ptr.ref.lpVtbl, other == null ? nullptr : other.ptr.ref.lpVtbl);
+        ptr.ref.lpVtbl, otherPtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/packages/windows_globalization/lib/src/icalendarfactory.dart
+++ b/packages/windows_globalization/lib/src/icalendarfactory.dart
@@ -32,6 +32,11 @@ class ICalendarFactory extends IInspectable {
 
   Calendar createCalendarDefaultCalendarAndClock(IIterable<String> languages) {
     final retValuePtr = calloc<COMObject>();
+    final languagesPtr = IInspectable(
+            languages.toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+        .ptr
+        .ref
+        .lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(6)
@@ -44,12 +49,14 @@ class ICalendarFactory extends IInspectable {
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL languages,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl, languages.ptr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, languagesPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
     }
+
+    languages.release();
 
     return Calendar.fromRawPointer(retValuePtr);
   }
@@ -57,7 +64,11 @@ class ICalendarFactory extends IInspectable {
   Calendar createCalendar(
       IIterable<String> languages, String calendar, String clock) {
     final retValuePtr = calloc<COMObject>();
-
+    final languagesPtr = IInspectable(
+            languages.toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+        .ptr
+        .ref
+        .lpVtbl;
     final calendarHString = convertToHString(calendar);
     final clockHString = convertToHString(clock);
 
@@ -77,7 +88,7 @@ class ICalendarFactory extends IInspectable {
                 int Function(LPVTBL lpVtbl, LPVTBL languages, int calendar,
                     int clock, Pointer<COMObject> retValuePtr)>()(
         ptr.ref.lpVtbl,
-        languages.ptr.ref.lpVtbl,
+        languagesPtr,
         calendarHString,
         clockHString,
         retValuePtr);
@@ -87,6 +98,7 @@ class ICalendarFactory extends IInspectable {
       throw WindowsException(hr);
     }
 
+    languages.release();
     WindowsDeleteString(calendarHString);
     WindowsDeleteString(clockHString);
 

--- a/packages/windows_globalization/lib/src/icalendarfactory2.dart
+++ b/packages/windows_globalization/lib/src/icalendarfactory2.dart
@@ -33,7 +33,11 @@ class ICalendarFactory2 extends IInspectable {
   Calendar createCalendarWithTimeZone(IIterable<String> languages,
       String calendar, String clock, String timeZoneId) {
     final retValuePtr = calloc<COMObject>();
-
+    final languagesPtr = IInspectable(
+            languages.toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+        .ptr
+        .ref
+        .lpVtbl;
     final calendarHString = convertToHString(calendar);
     final clockHString = convertToHString(clock);
     final timeZoneIdHString = convertToHString(timeZoneId);
@@ -60,7 +64,7 @@ class ICalendarFactory2 extends IInspectable {
                     int timeZoneId,
                     Pointer<COMObject> retValuePtr)>()(
         ptr.ref.lpVtbl,
-        languages.ptr.ref.lpVtbl,
+        languagesPtr,
         calendarHString,
         clockHString,
         timeZoneIdHString,
@@ -71,6 +75,7 @@ class ICalendarFactory2 extends IInspectable {
       throw WindowsException(hr);
     }
 
+    languages.release();
     WindowsDeleteString(calendarHString);
     WindowsDeleteString(clockHString);
     WindowsDeleteString(timeZoneIdHString);

--- a/packages/windows_globalization/lib/src/phonenumberformatting/iphonenumberformatter.dart
+++ b/packages/windows_globalization/lib/src/phonenumberformatting/iphonenumberformatter.dart
@@ -33,6 +33,7 @@ class IPhoneNumberFormatter extends IInspectable {
 
   String format(PhoneNumberInfo? number) {
     final retValuePtr = calloc<HSTRING>();
+    final numberPtr = number == null ? nullptr : number.ptr.ref.lpVtbl;
 
     try {
       final hr = ptr.ref.vtable
@@ -45,8 +46,8 @@ class IPhoneNumberFormatter extends IInspectable {
               .value
               .asFunction<
                   int Function(LPVTBL lpVtbl, LPVTBL number,
-                      Pointer<IntPtr> retValuePtr)>()(ptr.ref.lpVtbl,
-          number == null ? nullptr : number.ptr.ref.lpVtbl, retValuePtr);
+                      Pointer<IntPtr> retValuePtr)>()(
+          ptr.ref.lpVtbl, numberPtr, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -60,6 +61,7 @@ class IPhoneNumberFormatter extends IInspectable {
   String formatWithOutputFormat(
       PhoneNumberInfo? number, PhoneNumberFormat numberFormat) {
     final retValuePtr = calloc<HSTRING>();
+    final numberPtr = number == null ? nullptr : number.ptr.ref.lpVtbl;
 
     try {
       final hr =
@@ -77,10 +79,7 @@ class IPhoneNumberFormatter extends IInspectable {
                   .asFunction<
                       int Function(LPVTBL lpVtbl, LPVTBL number,
                           int numberFormat, Pointer<IntPtr> retValuePtr)>()(
-              ptr.ref.lpVtbl,
-              number == null ? nullptr : number.ptr.ref.lpVtbl,
-              numberFormat.value,
-              retValuePtr);
+              ptr.ref.lpVtbl, numberPtr, numberFormat.value, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/packages/windows_globalization/lib/src/phonenumberformatting/iphonenumberformatterstatics.dart
+++ b/packages/windows_globalization/lib/src/phonenumberformatting/iphonenumberformatterstatics.dart
@@ -33,6 +33,7 @@ class IPhoneNumberFormatterStatics extends IInspectable {
 
   void tryCreate(String regionCode, PhoneNumberFormatter phoneNumber) {
     final regionCodeHString = convertToHString(regionCode);
+    final phoneNumberPtr = phoneNumber.ptr;
 
     final hr = ptr.ref.vtable
             .elementAt(6)
@@ -45,7 +46,7 @@ class IPhoneNumberFormatterStatics extends IInspectable {
             .asFunction<
                 int Function(LPVTBL lpVtbl, int regionCode,
                     Pointer<COMObject> phoneNumber)>()(
-        ptr.ref.lpVtbl, regionCodeHString, phoneNumber.ptr);
+        ptr.ref.lpVtbl, regionCodeHString, phoneNumberPtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
 

--- a/packages/windows_globalization/lib/src/phonenumberformatting/iphonenumberinfo.dart
+++ b/packages/windows_globalization/lib/src/phonenumberformatting/iphonenumberinfo.dart
@@ -204,6 +204,8 @@ class IPhoneNumberInfo extends IInspectable {
 
   PhoneNumberMatchResult checkNumberMatch(PhoneNumberInfo? otherNumber) {
     final retValuePtr = calloc<Int32>();
+    final otherNumberPtr =
+        otherNumber == null ? nullptr : otherNumber.ptr.ref.lpVtbl;
 
     try {
       final hr = ptr.ref.vtable
@@ -217,9 +219,7 @@ class IPhoneNumberInfo extends IInspectable {
               .asFunction<
                   int Function(LPVTBL lpVtbl, LPVTBL otherNumber,
                       Pointer<Int32> retValuePtr)>()(
-          ptr.ref.lpVtbl,
-          otherNumber == null ? nullptr : otherNumber.ptr.ref.lpVtbl,
-          retValuePtr);
+          ptr.ref.lpVtbl, otherNumberPtr, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/packages/windows_globalization/lib/src/phonenumberformatting/iphonenumberinfostatics.dart
+++ b/packages/windows_globalization/lib/src/phonenumberformatting/iphonenumberinfostatics.dart
@@ -34,6 +34,7 @@ class IPhoneNumberInfoStatics extends IInspectable {
   PhoneNumberParseResult tryParse(String input, PhoneNumberInfo phoneNumber) {
     final retValuePtr = calloc<Int32>();
     final inputHString = convertToHString(input);
+    final phoneNumberPtr = phoneNumber.ptr;
 
     try {
       final hr = ptr.ref.vtable
@@ -53,7 +54,7 @@ class IPhoneNumberInfoStatics extends IInspectable {
                       int input,
                       Pointer<COMObject> phoneNumber,
                       Pointer<Int32> retValuePtr)>()(
-          ptr.ref.lpVtbl, inputHString, phoneNumber.ptr, retValuePtr);
+          ptr.ref.lpVtbl, inputHString, phoneNumberPtr, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -70,6 +71,7 @@ class IPhoneNumberInfoStatics extends IInspectable {
     final retValuePtr = calloc<Int32>();
     final inputHString = convertToHString(input);
     final regionCodeHString = convertToHString(regionCode);
+    final phoneNumberPtr = phoneNumber.ptr;
 
     try {
       final hr = ptr.ref.vtable
@@ -91,7 +93,7 @@ class IPhoneNumberInfoStatics extends IInspectable {
                       int regionCode,
                       Pointer<COMObject> phoneNumber,
                       Pointer<Int32> retValuePtr)>()(ptr.ref.lpVtbl,
-          inputHString, regionCodeHString, phoneNumber.ptr, retValuePtr);
+          inputHString, regionCodeHString, phoneNumberPtr, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/packages/windows_networking/lib/src/connectivity/inetworkinformationstatics.dart
+++ b/packages/windows_networking/lib/src/connectivity/inetworkinformationstatics.dart
@@ -190,6 +190,13 @@ class INetworkInformationStatics extends IInspectable {
       IIterable<EndpointPair>? destinationList,
       HostNameSortOptions sortOptions) {
     final retValuePtr = calloc<COMObject>();
+    final destinationListPtr = destinationList == null
+        ? nullptr
+        : IInspectable(destinationList
+                .toInterface('{d7ec83c4-a17b-51bf-8997-aa33b9102dc9}'))
+            .ptr
+            .ref
+            .lpVtbl;
 
     final hr =
         ptr.ref.vtable
@@ -206,10 +213,7 @@ class INetworkInformationStatics extends IInspectable {
                 .asFunction<
                     int Function(LPVTBL lpVtbl, LPVTBL destinationList,
                         int sortOptions, Pointer<COMObject> retValuePtr)>()(
-            ptr.ref.lpVtbl,
-            destinationList == null ? nullptr : destinationList.ptr.ref.lpVtbl,
-            sortOptions.value,
-            retValuePtr);
+            ptr.ref.lpVtbl, destinationListPtr, sortOptions.value, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -221,6 +225,8 @@ class INetworkInformationStatics extends IInspectable {
         creator: EndpointPair.fromRawPointer);
     final list = vectorView.toList();
     vectorView.release();
+
+    destinationList?.release();
 
     return list;
   }

--- a/packages/windows_networking/lib/src/connectivity/inetworkinformationstatics2.dart
+++ b/packages/windows_networking/lib/src/connectivity/inetworkinformationstatics2.dart
@@ -36,6 +36,8 @@ class INetworkInformationStatics2 extends IInspectable {
       ConnectionProfileFilter? pProfileFilter) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<List<ConnectionProfile>>();
+    final pProfileFilterPtr =
+        pProfileFilter == null ? nullptr : pProfileFilter.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(6)
@@ -48,9 +50,7 @@ class INetworkInformationStatics2 extends IInspectable {
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL pProfileFilter,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        pProfileFilter == null ? nullptr : pProfileFilter.ptr.ref.lpVtbl,
-        retValuePtr);
+        ptr.ref.lpVtbl, pProfileFilterPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_networking/lib/src/iendpointpairfactory.dart
+++ b/packages/windows_networking/lib/src/iendpointpairfactory.dart
@@ -37,9 +37,9 @@ class IEndpointPairFactory extends IInspectable {
       HostName remoteHostName,
       String remoteServiceName) {
     final retValuePtr = calloc<COMObject>();
-
+    final localHostNamePtr = localHostName.ptr.ref.lpVtbl;
     final localServiceNameHString = convertToHString(localServiceName);
-
+    final remoteHostNamePtr = remoteHostName.ptr.ref.lpVtbl;
     final remoteServiceNameHString = convertToHString(remoteServiceName);
 
     final hr = ptr.ref.vtable
@@ -64,9 +64,9 @@ class IEndpointPairFactory extends IInspectable {
                     int remoteServiceName,
                     Pointer<COMObject> retValuePtr)>()(
         ptr.ref.lpVtbl,
-        localHostName.ptr.ref.lpVtbl,
+        localHostNamePtr,
         localServiceNameHString,
-        remoteHostName.ptr.ref.lpVtbl,
+        remoteHostNamePtr,
         remoteServiceNameHString,
         retValuePtr);
 

--- a/packages/windows_networking/lib/src/ihostname.dart
+++ b/packages/windows_networking/lib/src/ihostname.dart
@@ -160,6 +160,7 @@ class IHostName extends IInspectable {
 
   bool isEqual(HostName? hostName) {
     final retValuePtr = calloc<Bool>();
+    final hostNamePtr = hostName == null ? nullptr : hostName.ptr.ref.lpVtbl;
 
     try {
       final hr = ptr.ref.vtable
@@ -172,8 +173,8 @@ class IHostName extends IInspectable {
               .value
               .asFunction<
                   int Function(LPVTBL lpVtbl, LPVTBL hostName,
-                      Pointer<Bool> retValuePtr)>()(ptr.ref.lpVtbl,
-          hostName == null ? nullptr : hostName.ptr.ref.lpVtbl, retValuePtr);
+                      Pointer<Bool> retValuePtr)>()(
+          ptr.ref.lpVtbl, hostNamePtr, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/packages/windows_storage/lib/src/fileproperties/istorageitemextraproperties.dart
+++ b/packages/windows_storage/lib/src/fileproperties/istorageitemextraproperties.dart
@@ -33,10 +33,16 @@ class IStorageItemExtraProperties extends IInspectable {
       IIterable<String>? propertiesToRetrieve) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<IMap<String, Object?>>();
+    final propertiesToRetrievePtr = propertiesToRetrieve == null
+        ? nullptr
+        : IInspectable(propertiesToRetrieve
+                .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+            .ptr
+            .ref
+            .lpVtbl;
 
     final hr =
-        ptr
-                .ref.vtable
+        ptr.ref.vtable
                 .elementAt(6)
                 .cast<
                     Pointer<
@@ -49,16 +55,14 @@ class IStorageItemExtraProperties extends IInspectable {
                 .asFunction<
                     int Function(LPVTBL lpVtbl, LPVTBL propertiesToRetrieve,
                         Pointer<COMObject> retValuePtr)>()(
-            ptr.ref.lpVtbl,
-            propertiesToRetrieve == null
-                ? nullptr
-                : propertiesToRetrieve.ptr.ref.lpVtbl,
-            retValuePtr);
+            ptr.ref.lpVtbl, propertiesToRetrievePtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
     }
+
+    propertiesToRetrieve?.release();
 
     final asyncOperation =
         IAsyncOperation<IMap<String, Object?>>.fromRawPointer(retValuePtr,
@@ -74,6 +78,13 @@ class IStorageItemExtraProperties extends IInspectable {
       IIterable<IKeyValuePair<String, Object?>>? propertiesToSave) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<void>();
+    final propertiesToSavePtr = propertiesToSave == null
+        ? nullptr
+        : IInspectable(propertiesToSave
+                .toInterface('{fe2f3d47-5d47-5499-8374-430c7cda0204}'))
+            .ptr
+            .ref
+            .lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(7)
@@ -86,14 +97,14 @@ class IStorageItemExtraProperties extends IInspectable {
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL propertiesToSave,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        propertiesToSave == null ? nullptr : propertiesToSave.ptr.ref.lpVtbl,
-        retValuePtr);
+        ptr.ref.lpVtbl, propertiesToSavePtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
     }
+
+    propertiesToSave?.release();
 
     final asyncAction = IAsyncAction.fromRawPointer(retValuePtr);
     completeAsyncAction(asyncAction, completer);

--- a/packages/windows_storage/lib/src/iknownfoldersstatics3.dart
+++ b/packages/windows_storage/lib/src/iknownfoldersstatics3.dart
@@ -36,6 +36,7 @@ class IKnownFoldersStatics3 extends IInspectable {
       User? user, KnownFolderId folderId) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<StorageFolder?>();
+    final userPtr = user == null ? nullptr : user.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(6)
@@ -48,10 +49,7 @@ class IKnownFoldersStatics3 extends IInspectable {
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL user, int folderId,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        user == null ? nullptr : user.ptr.ref.lpVtbl,
-        folderId.value,
-        retValuePtr);
+        ptr.ref.lpVtbl, userPtr, folderId.value, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_storage/lib/src/iknownfoldersstatics4.dart
+++ b/packages/windows_storage/lib/src/iknownfoldersstatics4.dart
@@ -67,6 +67,7 @@ class IKnownFoldersStatics4 extends IInspectable {
       User? user, KnownFolderId folderId) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<KnownFoldersAccessStatus>();
+    final userPtr = user == null ? nullptr : user.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(7)
@@ -79,10 +80,7 @@ class IKnownFoldersStatics4 extends IInspectable {
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL user, int folderId,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        user == null ? nullptr : user.ptr.ref.lpVtbl,
-        folderId.value,
-        retValuePtr);
+        ptr.ref.lpVtbl, userPtr, folderId.value, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_storage/lib/src/istoragefile.dart
+++ b/packages/windows_storage/lib/src/istoragefile.dart
@@ -158,6 +158,8 @@ class IStorageFile extends IInspectable
       IStorageFolder? destinationFolder) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<StorageFile?>();
+    final destinationFolderPtr =
+        destinationFolder == null ? nullptr : destinationFolder.ptr.ref.lpVtbl;
 
     final hr =
         ptr.ref.vtable
@@ -173,11 +175,7 @@ class IStorageFile extends IInspectable
                 .asFunction<
                     int Function(LPVTBL lpVtbl, LPVTBL destinationFolder,
                         Pointer<COMObject> retValuePtr)>()(
-            ptr.ref.lpVtbl,
-            destinationFolder == null
-                ? nullptr
-                : destinationFolder.ptr.ref.lpVtbl,
-            retValuePtr);
+            ptr.ref.lpVtbl, destinationFolderPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -197,7 +195,8 @@ class IStorageFile extends IInspectable
       IStorageFolder? destinationFolder, String desiredNewName) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<StorageFile?>();
-
+    final destinationFolderPtr =
+        destinationFolder == null ? nullptr : destinationFolder.ptr.ref.lpVtbl;
     final desiredNewNameHString = convertToHString(desiredNewName);
 
     final hr = ptr.ref.vtable
@@ -215,7 +214,7 @@ class IStorageFile extends IInspectable
                 int Function(LPVTBL lpVtbl, LPVTBL destinationFolder,
                     int desiredNewName, Pointer<COMObject> retValuePtr)>()(
         ptr.ref.lpVtbl,
-        destinationFolder == null ? nullptr : destinationFolder.ptr.ref.lpVtbl,
+        destinationFolderPtr,
         desiredNewNameHString,
         retValuePtr);
 
@@ -239,7 +238,8 @@ class IStorageFile extends IInspectable
       String desiredNewName, NameCollisionOption option) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<StorageFile?>();
-
+    final destinationFolderPtr =
+        destinationFolder == null ? nullptr : destinationFolder.ptr.ref.lpVtbl;
     final desiredNewNameHString = convertToHString(desiredNewName);
 
     final hr = ptr.ref.vtable
@@ -260,12 +260,8 @@ class IStorageFile extends IInspectable
                     LPVTBL destinationFolder,
                     int desiredNewName,
                     int option,
-                    Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        destinationFolder == null ? nullptr : destinationFolder.ptr.ref.lpVtbl,
-        desiredNewNameHString,
-        option.value,
-        retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
+        destinationFolderPtr, desiredNewNameHString, option.value, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -286,6 +282,8 @@ class IStorageFile extends IInspectable
   Future<void> copyAndReplaceAsync(IStorageFile? fileToReplace) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<void>();
+    final fileToReplacePtr =
+        fileToReplace == null ? nullptr : fileToReplace.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(13)
@@ -298,9 +296,7 @@ class IStorageFile extends IInspectable
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL fileToReplace,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        fileToReplace == null ? nullptr : fileToReplace.ptr.ref.lpVtbl,
-        retValuePtr);
+        ptr.ref.lpVtbl, fileToReplacePtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -317,6 +313,8 @@ class IStorageFile extends IInspectable
       IStorageFolder? destinationFolder) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<void>();
+    final destinationFolderPtr =
+        destinationFolder == null ? nullptr : destinationFolder.ptr.ref.lpVtbl;
 
     final hr =
         ptr.ref.vtable
@@ -332,11 +330,7 @@ class IStorageFile extends IInspectable
                 .asFunction<
                     int Function(LPVTBL lpVtbl, LPVTBL destinationFolder,
                         Pointer<COMObject> retValuePtr)>()(
-            ptr.ref.lpVtbl,
-            destinationFolder == null
-                ? nullptr
-                : destinationFolder.ptr.ref.lpVtbl,
-            retValuePtr);
+            ptr.ref.lpVtbl, destinationFolderPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -353,7 +347,8 @@ class IStorageFile extends IInspectable
       IStorageFolder? destinationFolder, String desiredNewName) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<void>();
-
+    final destinationFolderPtr =
+        destinationFolder == null ? nullptr : destinationFolder.ptr.ref.lpVtbl;
     final desiredNewNameHString = convertToHString(desiredNewName);
 
     final hr = ptr.ref.vtable
@@ -371,7 +366,7 @@ class IStorageFile extends IInspectable
                 int Function(LPVTBL lpVtbl, LPVTBL destinationFolder,
                     int desiredNewName, Pointer<COMObject> retValuePtr)>()(
         ptr.ref.lpVtbl,
-        destinationFolder == null ? nullptr : destinationFolder.ptr.ref.lpVtbl,
+        destinationFolderPtr,
         desiredNewNameHString,
         retValuePtr);
 
@@ -392,7 +387,8 @@ class IStorageFile extends IInspectable
       String desiredNewName, NameCollisionOption option) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<void>();
-
+    final destinationFolderPtr =
+        destinationFolder == null ? nullptr : destinationFolder.ptr.ref.lpVtbl;
     final desiredNewNameHString = convertToHString(desiredNewName);
 
     final hr = ptr.ref.vtable
@@ -413,12 +409,8 @@ class IStorageFile extends IInspectable
                     LPVTBL destinationFolder,
                     int desiredNewName,
                     int option,
-                    Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        destinationFolder == null ? nullptr : destinationFolder.ptr.ref.lpVtbl,
-        desiredNewNameHString,
-        option.value,
-        retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
+        destinationFolderPtr, desiredNewNameHString, option.value, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -436,6 +428,8 @@ class IStorageFile extends IInspectable
   Future<void> moveAndReplaceAsync(IStorageFile? fileToReplace) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<void>();
+    final fileToReplacePtr =
+        fileToReplace == null ? nullptr : fileToReplace.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(17)
@@ -448,9 +442,7 @@ class IStorageFile extends IInspectable
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL fileToReplace,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        fileToReplace == null ? nullptr : fileToReplace.ptr.ref.lpVtbl,
-        retValuePtr);
+        ptr.ref.lpVtbl, fileToReplacePtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_storage/lib/src/istoragefilestatics.dart
+++ b/packages/windows_storage/lib/src/istoragefilestatics.dart
@@ -110,6 +110,8 @@ class IStorageFileStatics extends IInspectable {
     final displayNameWithExtensionHString =
         convertToHString(displayNameWithExtension);
 
+    final thumbnailPtr = thumbnail == null ? nullptr : thumbnail.ptr.ref.lpVtbl;
+
     final hr = ptr.ref.vtable
             .elementAt(8)
             .cast<
@@ -132,7 +134,7 @@ class IStorageFileStatics extends IInspectable {
         ptr.ref.lpVtbl,
         displayNameWithExtensionHString,
         dataRequested.ref.lpVtbl,
-        thumbnail == null ? nullptr : thumbnail.ptr.ref.lpVtbl,
+        thumbnailPtr,
         retValuePtr);
 
     if (FAILED(hr)) {
@@ -157,6 +159,10 @@ class IStorageFileStatics extends IInspectable {
       IRandomAccessStreamReference? thumbnail) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<StorageFile?>();
+    final fileToReplacePtr =
+        fileToReplace == null ? nullptr : fileToReplace.ptr.ref.lpVtbl;
+
+    final thumbnailPtr = thumbnail == null ? nullptr : thumbnail.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(9)
@@ -176,12 +182,8 @@ class IStorageFileStatics extends IInspectable {
                     LPVTBL fileToReplace,
                     LPVTBL dataRequested,
                     LPVTBL thumbnail,
-                    Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        fileToReplace == null ? nullptr : fileToReplace.ptr.ref.lpVtbl,
-        dataRequested.ref.lpVtbl,
-        thumbnail == null ? nullptr : thumbnail.ptr.ref.lpVtbl,
-        retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
+        fileToReplacePtr, dataRequested.ref.lpVtbl, thumbnailPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -206,6 +208,7 @@ class IStorageFileStatics extends IInspectable {
     final displayNameWithExtensionHString =
         convertToHString(displayNameWithExtension);
     final uriUri = uri == null ? null : winrt_uri.Uri.createUri(uri.toString());
+    final thumbnailPtr = thumbnail == null ? nullptr : thumbnail.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(10)
@@ -229,7 +232,7 @@ class IStorageFileStatics extends IInspectable {
         ptr.ref.lpVtbl,
         displayNameWithExtensionHString,
         uriUri == null ? nullptr : uriUri.ptr.ref.lpVtbl,
-        thumbnail == null ? nullptr : thumbnail.ptr.ref.lpVtbl,
+        thumbnailPtr,
         retValuePtr);
 
     if (FAILED(hr)) {
@@ -255,8 +258,10 @@ class IStorageFileStatics extends IInspectable {
       IRandomAccessStreamReference? thumbnail) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<StorageFile?>();
-
+    final fileToReplacePtr =
+        fileToReplace == null ? nullptr : fileToReplace.ptr.ref.lpVtbl;
     final uriUri = uri == null ? null : winrt_uri.Uri.createUri(uri.toString());
+    final thumbnailPtr = thumbnail == null ? nullptr : thumbnail.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(11)
@@ -274,9 +279,9 @@ class IStorageFileStatics extends IInspectable {
                 int Function(LPVTBL lpVtbl, LPVTBL fileToReplace, LPVTBL uri,
                     LPVTBL thumbnail, Pointer<COMObject> retValuePtr)>()(
         ptr.ref.lpVtbl,
-        fileToReplace == null ? nullptr : fileToReplace.ptr.ref.lpVtbl,
+        fileToReplacePtr,
         uriUri == null ? nullptr : uriUri.ptr.ref.lpVtbl,
-        thumbnail == null ? nullptr : thumbnail.ptr.ref.lpVtbl,
+        thumbnailPtr,
         retValuePtr);
 
     if (FAILED(hr)) {

--- a/packages/windows_storage/lib/src/istoragefilestatics2.dart
+++ b/packages/windows_storage/lib/src/istoragefilestatics2.dart
@@ -34,7 +34,7 @@ class IStorageFileStatics2 extends IInspectable {
   Future<StorageFile?> getFileFromPathForUserAsync(User? user, String path) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<StorageFile?>();
-
+    final userPtr = user == null ? nullptr : user.ptr.ref.lpVtbl;
     final pathHString = convertToHString(path);
 
     final hr = ptr.ref.vtable
@@ -47,8 +47,8 @@ class IStorageFileStatics2 extends IInspectable {
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL user, int path,
-                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
-        user == null ? nullptr : user.ptr.ref.lpVtbl, pathHString, retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(
+        ptr.ref.lpVtbl, userPtr, pathHString, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_storage/lib/src/istoragefolderstatics2.dart
+++ b/packages/windows_storage/lib/src/istoragefolderstatics2.dart
@@ -35,7 +35,7 @@ class IStorageFolderStatics2 extends IInspectable {
       User? user, String path) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<StorageFolder?>();
-
+    final userPtr = user == null ? nullptr : user.ptr.ref.lpVtbl;
     final pathHString = convertToHString(path);
 
     final hr = ptr.ref.vtable
@@ -48,8 +48,8 @@ class IStorageFolderStatics2 extends IInspectable {
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL user, int path,
-                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
-        user == null ? nullptr : user.ptr.ref.lpVtbl, pathHString, retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(
+        ptr.ref.lpVtbl, userPtr, pathHString, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_storage/lib/src/istorageitem2.dart
+++ b/packages/windows_storage/lib/src/istorageitem2.dart
@@ -64,6 +64,7 @@ class IStorageItem2 extends IInspectable implements IStorageItem {
 
   bool isEqual(IStorageItem? item) {
     final retValuePtr = calloc<Bool>();
+    final itemPtr = item == null ? nullptr : item.ptr.ref.lpVtbl;
 
     try {
       final hr = ptr.ref.vtable
@@ -77,9 +78,7 @@ class IStorageItem2 extends IInspectable implements IStorageItem {
               .asFunction<
                   int Function(
                       LPVTBL lpVtbl, LPVTBL item, Pointer<Bool> retValuePtr)>()(
-          ptr.ref.lpVtbl,
-          item == null ? nullptr : item.ptr.ref.lpVtbl,
-          retValuePtr);
+          ptr.ref.lpVtbl, itemPtr, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/packages/windows_storage/lib/src/istoragelibrarychangetracker2.dart
+++ b/packages/windows_storage/lib/src/istoragelibrarychangetracker2.dart
@@ -32,6 +32,8 @@ class IStorageLibraryChangeTracker2 extends IInspectable {
           interface.toInterface(IID_IStorageLibraryChangeTracker2));
 
   void enableWithOptions(StorageLibraryChangeTrackerOptions? options) {
+    final optionsPtr = options == null ? nullptr : options.ptr.ref.lpVtbl;
+
     final hr = ptr.ref.vtable
             .elementAt(6)
             .cast<
@@ -40,7 +42,7 @@ class IStorageLibraryChangeTracker2 extends IInspectable {
                         HRESULT Function(LPVTBL lpVtbl, LPVTBL options)>>>()
             .value
             .asFunction<int Function(LPVTBL lpVtbl, LPVTBL options)>()(
-        ptr.ref.lpVtbl, options == null ? nullptr : options.ptr.ref.lpVtbl);
+        ptr.ref.lpVtbl, optionsPtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/packages/windows_storage/lib/src/iuserdatapathsstatics.dart
+++ b/packages/windows_storage/lib/src/iuserdatapathsstatics.dart
@@ -33,6 +33,7 @@ class IUserDataPathsStatics extends IInspectable {
 
   UserDataPaths? getForUser(User? user) {
     final retValuePtr = calloc<COMObject>();
+    final userPtr = user == null ? nullptr : user.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(6)
@@ -44,8 +45,8 @@ class IUserDataPathsStatics extends IInspectable {
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL user,
-                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
-        user == null ? nullptr : user.ptr.ref.lpVtbl, retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(
+        ptr.ref.lpVtbl, userPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_storage/lib/src/pickers/ifileopenpickerstatics2.dart
+++ b/packages/windows_storage/lib/src/pickers/ifileopenpickerstatics2.dart
@@ -33,6 +33,7 @@ class IFileOpenPickerStatics2 extends IInspectable {
 
   FileOpenPicker? createForUser(User? user) {
     final retValuePtr = calloc<COMObject>();
+    final userPtr = user == null ? nullptr : user.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(6)
@@ -44,8 +45,8 @@ class IFileOpenPickerStatics2 extends IInspectable {
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL user,
-                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
-        user == null ? nullptr : user.ptr.ref.lpVtbl, retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(
+        ptr.ref.lpVtbl, userPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_storage/lib/src/pickers/ifilesavepickerstatics.dart
+++ b/packages/windows_storage/lib/src/pickers/ifilesavepickerstatics.dart
@@ -33,6 +33,7 @@ class IFileSavePickerStatics extends IInspectable {
 
   FileSavePicker? createForUser(User? user) {
     final retValuePtr = calloc<COMObject>();
+    final userPtr = user == null ? nullptr : user.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(6)
@@ -44,8 +45,8 @@ class IFileSavePickerStatics extends IInspectable {
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL user,
-                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
-        user == null ? nullptr : user.ptr.ref.lpVtbl, retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(
+        ptr.ref.lpVtbl, userPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_storage/lib/src/pickers/ifolderpickerstatics.dart
+++ b/packages/windows_storage/lib/src/pickers/ifolderpickerstatics.dart
@@ -33,6 +33,7 @@ class IFolderPickerStatics extends IInspectable {
 
   FolderPicker? createForUser(User? user) {
     final retValuePtr = calloc<COMObject>();
+    final userPtr = user == null ? nullptr : user.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(6)
@@ -44,8 +45,8 @@ class IFolderPickerStatics extends IInspectable {
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL user,
-                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
-        user == null ? nullptr : user.ptr.ref.lpVtbl, retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(
+        ptr.ref.lpVtbl, userPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_storage/lib/src/search/iqueryoptions.dart
+++ b/packages/windows_storage/lib/src/search/iqueryoptions.dart
@@ -402,6 +402,14 @@ class IQueryOptions extends IInspectable {
 
   void setPropertyPrefetch(PropertyPrefetchOptions options,
       IIterable<String>? propertiesToRetrieve) {
+    final propertiesToRetrievePtr = propertiesToRetrieve == null
+        ? nullptr
+        : IInspectable(propertiesToRetrieve
+                .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+            .ptr
+            .ref
+            .lpVtbl;
+
     final hr = ptr.ref.vtable
             .elementAt(23)
             .cast<
@@ -413,12 +421,10 @@ class IQueryOptions extends IInspectable {
             .asFunction<
                 int Function(
                     LPVTBL lpVtbl, int options, LPVTBL propertiesToRetrieve)>()(
-        ptr.ref.lpVtbl,
-        options.value,
-        propertiesToRetrieve == null
-            ? nullptr
-            : propertiesToRetrieve.ptr.ref.lpVtbl);
+        ptr.ref.lpVtbl, options.value, propertiesToRetrievePtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
+
+    propertiesToRetrieve?.release();
   }
 }

--- a/packages/windows_storage/lib/src/search/iqueryoptionsfactory.dart
+++ b/packages/windows_storage/lib/src/search/iqueryoptionsfactory.dart
@@ -35,6 +35,12 @@ class IQueryOptionsFactory extends IInspectable {
       CommonFileQuery query, IIterable<String> fileTypeFilter) {
     final retValuePtr = calloc<COMObject>();
 
+    final fileTypeFilterPtr = IInspectable(fileTypeFilter
+            .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+        .ptr
+        .ref
+        .lpVtbl;
+
     final hr = ptr.ref.vtable
             .elementAt(6)
             .cast<
@@ -48,13 +54,15 @@ class IQueryOptionsFactory extends IInspectable {
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, int query, LPVTBL fileTypeFilter,
-                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
-        query.value, fileTypeFilter.ptr.ref.lpVtbl, retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(
+        ptr.ref.lpVtbl, query.value, fileTypeFilterPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
     }
+
+    fileTypeFilter.release();
 
     return QueryOptions.fromRawPointer(retValuePtr);
   }

--- a/packages/windows_storage/lib/src/search/istoragefilequeryresult2.dart
+++ b/packages/windows_storage/lib/src/search/istoragefilequeryresult2.dart
@@ -38,6 +38,7 @@ class IStorageFileQueryResult2 extends IInspectable
   IMap<String, IVectorView<TextSegment>?> getMatchingPropertiesWithRanges(
       StorageFile? file) {
     final retValuePtr = calloc<COMObject>();
+    final filePtr = file == null ? nullptr : file.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(6)
@@ -49,8 +50,8 @@ class IStorageFileQueryResult2 extends IInspectable
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL file,
-                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
-        file == null ? nullptr : file.ptr.ref.lpVtbl, retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(
+        ptr.ref.lpVtbl, filePtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_storage/lib/src/search/istoragefolderqueryoperations.dart
+++ b/packages/windows_storage/lib/src/search/istoragefolderqueryoperations.dart
@@ -128,6 +128,8 @@ class IStorageFolderQueryOperations extends IInspectable {
   StorageFileQueryResult? createFileQueryWithOptions(
       QueryOptions? queryOptions) {
     final retValuePtr = calloc<COMObject>();
+    final queryOptionsPtr =
+        queryOptions == null ? nullptr : queryOptions.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(9)
@@ -140,9 +142,7 @@ class IStorageFolderQueryOperations extends IInspectable {
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL queryOptions,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        queryOptions == null ? nullptr : queryOptions.ptr.ref.lpVtbl,
-        retValuePtr);
+        ptr.ref.lpVtbl, queryOptionsPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -217,6 +217,8 @@ class IStorageFolderQueryOperations extends IInspectable {
   StorageFolderQueryResult? createFolderQueryWithOptions(
       QueryOptions? queryOptions) {
     final retValuePtr = calloc<COMObject>();
+    final queryOptionsPtr =
+        queryOptions == null ? nullptr : queryOptions.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(12)
@@ -229,9 +231,7 @@ class IStorageFolderQueryOperations extends IInspectable {
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL queryOptions,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        queryOptions == null ? nullptr : queryOptions.ptr.ref.lpVtbl,
-        retValuePtr);
+        ptr.ref.lpVtbl, queryOptionsPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -277,6 +277,8 @@ class IStorageFolderQueryOperations extends IInspectable {
   StorageItemQueryResult? createItemQueryWithOptions(
       QueryOptions? queryOptions) {
     final retValuePtr = calloc<COMObject>();
+    final queryOptionsPtr =
+        queryOptions == null ? nullptr : queryOptions.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(14)
@@ -289,9 +291,7 @@ class IStorageFolderQueryOperations extends IInspectable {
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL queryOptions,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        queryOptions == null ? nullptr : queryOptions.ptr.ref.lpVtbl,
-        retValuePtr);
+        ptr.ref.lpVtbl, queryOptionsPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -499,6 +499,8 @@ class IStorageFolderQueryOperations extends IInspectable {
 
   bool areQueryOptionsSupported(QueryOptions? queryOptions) {
     final retValuePtr = calloc<Bool>();
+    final queryOptionsPtr =
+        queryOptions == null ? nullptr : queryOptions.ptr.ref.lpVtbl;
 
     try {
       final hr = ptr.ref.vtable
@@ -512,9 +514,7 @@ class IStorageFolderQueryOperations extends IInspectable {
               .asFunction<
                   int Function(LPVTBL lpVtbl, LPVTBL queryOptions,
                       Pointer<Bool> retValuePtr)>()(
-          ptr.ref.lpVtbl,
-          queryOptions == null ? nullptr : queryOptions.ptr.ref.lpVtbl,
-          retValuePtr);
+          ptr.ref.lpVtbl, queryOptionsPtr, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/packages/windows_storage/lib/src/search/istoragequeryresultbase.dart
+++ b/packages/windows_storage/lib/src/search/istoragequeryresultbase.dart
@@ -169,6 +169,7 @@ class IStorageQueryResultBase extends IInspectable {
   Future<int> findStartIndexAsync(Object? value) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<int>();
+    final valuePtr = value?.intoBox().ref.lpVtbl ?? nullptr;
 
     final hr = ptr.ref.vtable
             .elementAt(12)
@@ -181,7 +182,7 @@ class IStorageQueryResultBase extends IInspectable {
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL value,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl, value?.intoBox().ref.lpVtbl ?? nullptr, retValuePtr);
+        ptr.ref.lpVtbl, valuePtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -225,19 +226,19 @@ class IStorageQueryResultBase extends IInspectable {
   }
 
   void applyNewQueryOptions(QueryOptions? newQueryOptions) {
-    final hr =
-        ptr.ref.vtable
-                .elementAt(14)
-                .cast<
-                    Pointer<
-                        NativeFunction<
-                            HRESULT Function(
-                                LPVTBL lpVtbl, LPVTBL newQueryOptions)>>>()
-                .value
-                .asFunction<
-                    int Function(LPVTBL lpVtbl, LPVTBL newQueryOptions)>()(
-            ptr.ref.lpVtbl,
-            newQueryOptions == null ? nullptr : newQueryOptions.ptr.ref.lpVtbl);
+    final newQueryOptionsPtr =
+        newQueryOptions == null ? nullptr : newQueryOptions.ptr.ref.lpVtbl;
+
+    final hr = ptr.ref.vtable
+        .elementAt(14)
+        .cast<
+            Pointer<
+                NativeFunction<
+                    HRESULT Function(LPVTBL lpVtbl, LPVTBL newQueryOptions)>>>()
+        .value
+        .asFunction<
+            int Function(LPVTBL lpVtbl,
+                LPVTBL newQueryOptions)>()(ptr.ref.lpVtbl, newQueryOptionsPtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/packages/windows_storage/lib/src/streams/iinputstream.dart
+++ b/packages/windows_storage/lib/src/streams/iinputstream.dart
@@ -33,6 +33,7 @@ class IInputStream extends IInspectable implements IClosable {
   Pointer<COMObject> readAsync(
       IBuffer? buffer, int count, InputStreamOptions options) {
     final retValuePtr = calloc<COMObject>();
+    final bufferPtr = buffer == null ? nullptr : buffer.ptr.ref.lpVtbl;
 
     final hr =
         ptr.ref.vtable
@@ -50,11 +51,7 @@ class IInputStream extends IInspectable implements IClosable {
                 .asFunction<
                     int Function(LPVTBL lpVtbl, LPVTBL buffer, int count,
                         int options, Pointer<COMObject> retValuePtr)>()(
-            ptr.ref.lpVtbl,
-            buffer == null ? nullptr : buffer.ptr.ref.lpVtbl,
-            count,
-            options.value,
-            retValuePtr);
+            ptr.ref.lpVtbl, bufferPtr, count, options.value, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_storage/lib/src/streams/ioutputstream.dart
+++ b/packages/windows_storage/lib/src/streams/ioutputstream.dart
@@ -31,6 +31,7 @@ class IOutputStream extends IInspectable implements IClosable {
 
   Pointer<COMObject> writeAsync(IBuffer? buffer) {
     final retValuePtr = calloc<COMObject>();
+    final bufferPtr = buffer == null ? nullptr : buffer.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(6)
@@ -42,8 +43,8 @@ class IOutputStream extends IInspectable implements IClosable {
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL buffer,
-                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
-        buffer == null ? nullptr : buffer.ptr.ref.lpVtbl, retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(
+        ptr.ref.lpVtbl, bufferPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_ui/lib/src/notifications/inotificationdatafactory.dart
+++ b/packages/windows_ui/lib/src/notifications/inotificationdatafactory.dart
@@ -34,6 +34,11 @@ class INotificationDataFactory extends IInspectable {
       IIterable<IKeyValuePair<String, String>> initialValues,
       int sequenceNumber) {
     final retValuePtr = calloc<COMObject>();
+    final initialValuesPtr = IInspectable(
+            initialValues.toInterface('{e9bdaaf0-cbf6-5c72-be90-29cbf3a1319b}'))
+        .ptr
+        .ref
+        .lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(6)
@@ -49,15 +54,14 @@ class INotificationDataFactory extends IInspectable {
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL initialValues,
                     int sequenceNumber, Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl,
-        initialValues.ptr.ref.lpVtbl,
-        sequenceNumber,
-        retValuePtr);
+        ptr.ref.lpVtbl, initialValuesPtr, sequenceNumber, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
     }
+
+    initialValues.release();
 
     return NotificationData.fromRawPointer(retValuePtr);
   }
@@ -65,6 +69,11 @@ class INotificationDataFactory extends IInspectable {
   NotificationData createNotificationDataWithValues(
       IIterable<IKeyValuePair<String, String>> initialValues) {
     final retValuePtr = calloc<COMObject>();
+    final initialValuesPtr = IInspectable(
+            initialValues.toInterface('{e9bdaaf0-cbf6-5c72-be90-29cbf3a1319b}'))
+        .ptr
+        .ref
+        .lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(7)
@@ -77,12 +86,14 @@ class INotificationDataFactory extends IInspectable {
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL initialValues,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl, initialValues.ptr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, initialValuesPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
       throw WindowsException(hr);
     }
+
+    initialValues.release();
 
     return NotificationData.fromRawPointer(retValuePtr);
   }

--- a/packages/windows_ui/lib/src/notifications/ischeduledtoastnotificationfactory.dart
+++ b/packages/windows_ui/lib/src/notifications/ischeduledtoastnotificationfactory.dart
@@ -35,7 +35,7 @@ class IScheduledToastNotificationFactory extends IInspectable {
   ScheduledToastNotification createScheduledToastNotification(
       XmlDocument content, DateTime deliveryTime) {
     final retValuePtr = calloc<COMObject>();
-
+    final contentPtr = content.ptr.ref.lpVtbl;
     final deliveryTimeDateTime =
         deliveryTime.difference(DateTime.utc(1601, 01, 01)).inMicroseconds * 10;
 
@@ -52,8 +52,8 @@ class IScheduledToastNotificationFactory extends IInspectable {
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL content, int deliveryTime,
-                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
-        content.ptr.ref.lpVtbl, deliveryTimeDateTime, retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(
+        ptr.ref.lpVtbl, contentPtr, deliveryTimeDateTime, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -69,7 +69,7 @@ class IScheduledToastNotificationFactory extends IInspectable {
       Duration snoozeInterval,
       int maximumSnoozeCount) {
     final retValuePtr = calloc<COMObject>();
-
+    final contentPtr = content.ptr.ref.lpVtbl;
     final deliveryTimeDateTime =
         deliveryTime.difference(DateTime.utc(1601, 01, 01)).inMicroseconds * 10;
     final snoozeIntervalDuration = snoozeInterval.inMicroseconds * 10;
@@ -96,7 +96,7 @@ class IScheduledToastNotificationFactory extends IInspectable {
                     int maximumSnoozeCount,
                     Pointer<COMObject> retValuePtr)>()(
         ptr.ref.lpVtbl,
-        content.ptr.ref.lpVtbl,
+        contentPtr,
         deliveryTimeDateTime,
         snoozeIntervalDuration,
         maximumSnoozeCount,

--- a/packages/windows_ui/lib/src/notifications/itoastcollectionmanager.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastcollectionmanager.dart
@@ -34,6 +34,8 @@ class IToastCollectionManager extends IInspectable {
   Future<void> saveToastCollectionAsync(ToastCollection? collection) {
     final retValuePtr = calloc<COMObject>();
     final completer = Completer<void>();
+    final collectionPtr =
+        collection == null ? nullptr : collection.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(6)
@@ -45,8 +47,8 @@ class IToastCollectionManager extends IInspectable {
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL collection,
-                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
-        collection == null ? nullptr : collection.ptr.ref.lpVtbl, retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(
+        ptr.ref.lpVtbl, collectionPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_ui/lib/src/notifications/itoastnotificationfactory.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotificationfactory.dart
@@ -33,6 +33,7 @@ class IToastNotificationFactory extends IInspectable {
 
   ToastNotification createToastNotification(XmlDocument content) {
     final retValuePtr = calloc<COMObject>();
+    final contentPtr = content.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(6)
@@ -45,7 +46,7 @@ class IToastNotificationFactory extends IInspectable {
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL content,
                     Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl, content.ptr.ref.lpVtbl, retValuePtr);
+        ptr.ref.lpVtbl, contentPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_ui/lib/src/notifications/itoastnotificationmanagerstatics4.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotificationmanagerstatics4.dart
@@ -35,6 +35,7 @@ class IToastNotificationManagerStatics4 extends IInspectable {
 
   ToastNotificationManagerForUser? getForUser(User? user) {
     final retValuePtr = calloc<COMObject>();
+    final userPtr = user == null ? nullptr : user.ptr.ref.lpVtbl;
 
     final hr = ptr.ref.vtable
             .elementAt(6)
@@ -46,8 +47,8 @@ class IToastNotificationManagerStatics4 extends IInspectable {
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, LPVTBL user,
-                    Pointer<COMObject> retValuePtr)>()(ptr.ref.lpVtbl,
-        user == null ? nullptr : user.ptr.ref.lpVtbl, retValuePtr);
+                    Pointer<COMObject> retValuePtr)>()(
+        ptr.ref.lpVtbl, userPtr, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_ui/lib/src/notifications/itoastnotifier.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotifier.dart
@@ -32,6 +32,9 @@ class IToastNotifier extends IInspectable {
       IToastNotifier.fromRawPointer(interface.toInterface(IID_IToastNotifier));
 
   void show(ToastNotification? notification) {
+    final notificationPtr =
+        notification == null ? nullptr : notification.ptr.ref.lpVtbl;
+
     final hr =
         ptr.ref.vtable
                 .elementAt(6)
@@ -42,13 +45,15 @@ class IToastNotifier extends IInspectable {
                                 LPVTBL lpVtbl, LPVTBL notification)>>>()
                 .value
                 .asFunction<int Function(LPVTBL lpVtbl, LPVTBL notification)>()(
-            ptr.ref.lpVtbl,
-            notification == null ? nullptr : notification.ptr.ref.lpVtbl);
+            ptr.ref.lpVtbl, notificationPtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void hide(ToastNotification? notification) {
+    final notificationPtr =
+        notification == null ? nullptr : notification.ptr.ref.lpVtbl;
+
     final hr =
         ptr.ref.vtable
                 .elementAt(7)
@@ -59,8 +64,7 @@ class IToastNotifier extends IInspectable {
                                 LPVTBL lpVtbl, LPVTBL notification)>>>()
                 .value
                 .asFunction<int Function(LPVTBL lpVtbl, LPVTBL notification)>()(
-            ptr.ref.lpVtbl,
-            notification == null ? nullptr : notification.ptr.ref.lpVtbl);
+            ptr.ref.lpVtbl, notificationPtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -90,37 +94,37 @@ class IToastNotifier extends IInspectable {
   }
 
   void addToSchedule(ScheduledToastNotification? scheduledToast) {
-    final hr =
-        ptr.ref.vtable
-                .elementAt(9)
-                .cast<
-                    Pointer<
-                        NativeFunction<
-                            HRESULT Function(
-                                LPVTBL lpVtbl, LPVTBL scheduledToast)>>>()
-                .value
-                .asFunction<
-                    int Function(LPVTBL lpVtbl, LPVTBL scheduledToast)>()(
-            ptr.ref.lpVtbl,
-            scheduledToast == null ? nullptr : scheduledToast.ptr.ref.lpVtbl);
+    final scheduledToastPtr =
+        scheduledToast == null ? nullptr : scheduledToast.ptr.ref.lpVtbl;
+
+    final hr = ptr.ref.vtable
+        .elementAt(9)
+        .cast<
+            Pointer<
+                NativeFunction<
+                    HRESULT Function(LPVTBL lpVtbl, LPVTBL scheduledToast)>>>()
+        .value
+        .asFunction<
+            int Function(LPVTBL lpVtbl,
+                LPVTBL scheduledToast)>()(ptr.ref.lpVtbl, scheduledToastPtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   void removeFromSchedule(ScheduledToastNotification? scheduledToast) {
-    final hr =
-        ptr.ref.vtable
-                .elementAt(10)
-                .cast<
-                    Pointer<
-                        NativeFunction<
-                            HRESULT Function(
-                                LPVTBL lpVtbl, LPVTBL scheduledToast)>>>()
-                .value
-                .asFunction<
-                    int Function(LPVTBL lpVtbl, LPVTBL scheduledToast)>()(
-            ptr.ref.lpVtbl,
-            scheduledToast == null ? nullptr : scheduledToast.ptr.ref.lpVtbl);
+    final scheduledToastPtr =
+        scheduledToast == null ? nullptr : scheduledToast.ptr.ref.lpVtbl;
+
+    final hr = ptr.ref.vtable
+        .elementAt(10)
+        .cast<
+            Pointer<
+                NativeFunction<
+                    HRESULT Function(LPVTBL lpVtbl, LPVTBL scheduledToast)>>>()
+        .value
+        .asFunction<
+            int Function(LPVTBL lpVtbl,
+                LPVTBL scheduledToast)>()(ptr.ref.lpVtbl, scheduledToastPtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/packages/windows_ui/lib/src/notifications/itoastnotifier2.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotifier2.dart
@@ -34,7 +34,7 @@ class IToastNotifier2 extends IInspectable {
   NotificationUpdateResult updateWithTagAndGroup(
       NotificationData? data, String tag, String group) {
     final retValuePtr = calloc<Int32>();
-
+    final dataPtr = data == null ? nullptr : data.ptr.ref.lpVtbl;
     final tagHString = convertToHString(tag);
     final groupHString = convertToHString(group);
 
@@ -55,11 +55,7 @@ class IToastNotifier2 extends IInspectable {
                   .asFunction<
                       int Function(LPVTBL lpVtbl, LPVTBL data, int tag,
                           int group, Pointer<Int32> retValuePtr)>()(
-              ptr.ref.lpVtbl,
-              data == null ? nullptr : data.ptr.ref.lpVtbl,
-              tagHString,
-              groupHString,
-              retValuePtr);
+              ptr.ref.lpVtbl, dataPtr, tagHString, groupHString, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -73,7 +69,7 @@ class IToastNotifier2 extends IInspectable {
 
   NotificationUpdateResult updateWithTag(NotificationData? data, String tag) {
     final retValuePtr = calloc<Int32>();
-
+    final dataPtr = data == null ? nullptr : data.ptr.ref.lpVtbl;
     final tagHString = convertToHString(tag);
 
     try {
@@ -89,10 +85,7 @@ class IToastNotifier2 extends IInspectable {
                   .asFunction<
                       int Function(LPVTBL lpVtbl, LPVTBL data, int tag,
                           Pointer<Int32> retValuePtr)>()(
-              ptr.ref.lpVtbl,
-              data == null ? nullptr : data.ptr.ref.lpVtbl,
-              tagHString,
-              retValuePtr);
+              ptr.ref.lpVtbl, dataPtr, tagHString, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 

--- a/packages/winrtgen/lib/src/projections/method.dart
+++ b/packages/winrtgen/lib/src/projections/method.dart
@@ -155,6 +155,9 @@ abstract class MethodProjection {
   /// The return type of the method (e.g. `String`).
   String get returnType => returnTypeProjection.dartType;
 
+  /// Whether the return type of the method is nullable.
+  bool get isNullable => returnType.endsWith('?');
+
   /// The header of the method.
   ///   e.g. `void setDateTime(DateTime value)` or `void setToNow()` (method)
   ///   e.g. `int get second` (getter)

--- a/packages/winrtgen/lib/src/projections/parameter.dart
+++ b/packages/winrtgen/lib/src/projections/parameter.dart
@@ -112,6 +112,9 @@ abstract class ParameterProjection {
   /// The type of the parameter (e.g. `String`).
   String get type => typeProjection.dartType;
 
+  /// Whether the type of the parameter is nullable.
+  bool get isNullable => type.endsWith('?');
+
   /// The name of the parameter that is safe to use as a Dart identifier.
   String get identifier => safeIdentifierForString(name);
 

--- a/packages/winrtgen/lib/src/projections/types/generic.dart
+++ b/packages/winrtgen/lib/src/projections/types/generic.dart
@@ -99,6 +99,7 @@ class GenericEnumListParameterProjection
 }
 
 mixin _GenericObjectMixin on MethodProjection {
+  @override
   bool get isNullable =>
       returnTypeProjection.genericTypeArg == TypeArg.nullableInspectable;
 

--- a/packages/winrtgen/lib/src/projections/types/object.dart
+++ b/packages/winrtgen/lib/src/projections/types/object.dart
@@ -62,7 +62,7 @@ mixin _ObjectMixin on MethodProjection {
   }
 
   String get nullCheck {
-    if (!returnType.endsWith('?')) return '';
+    if (!isNullable) return '';
     return '''
     if (retValuePtr.ref.isNull) {
       free(retValuePtr);

--- a/packages/winrtgen/lib/src/projections/types/object.dart
+++ b/packages/winrtgen/lib/src/projections/types/object.dart
@@ -155,25 +155,38 @@ class ObjectParameterProjection extends ParameterProjection {
   }
 
   @override
-  String get preamble => '';
-
-  @override
-  String get postamble => '';
-
-  @override
-  String get localIdentifier {
+  String get preamble {
+    final String expression;
     if (typeProjection.isObjectType) {
-      return '$name?.intoBox().ref.lpVtbl ?? nullptr';
+      expression = '$name?.intoBox().ref.lpVtbl ?? nullptr';
+    } else if (typeProjection.isReferenceType || typeProjection.isSimpleArray) {
+      expression =
+          type == 'Pointer<COMObject>' ? identifier : '$identifier.ptr';
+    } else if (type.startsWith('IIterable<')) {
+      final iid = typeProjection.typeIdentifier.iid;
+      final nullCheck = isNullable ? '$name == null ? nullptr : ' : '';
+      expression =
+          "${nullCheck}IInspectable($name.toInterface('$iid')).ptr.ref.lpVtbl";
+    } else {
+      expression = isNullable
+          ? '$name == null ? nullptr : $name.ptr.ref.lpVtbl'
+          : '$name.ptr.ref.lpVtbl';
     }
 
-    if (typeProjection.isReferenceType || typeProjection.isSimpleArray) {
-      return type == 'Pointer<COMObject>' ? identifier : '$identifier.ptr';
-    }
-
-    return type.endsWith('?')
-        ? '$name == null ? nullptr : $name.ptr.ref.lpVtbl'
-        : '$name.ptr.ref.lpVtbl';
+    return 'final ${name}Ptr = $expression;';
   }
+
+  @override
+  String get postamble {
+    if (type.startsWith('IIterable<')) {
+      return isNullable ? '$name?.release();' : '$name.release();';
+    }
+
+    return '';
+  }
+
+  @override
+  String get localIdentifier => '${name}Ptr';
 }
 
 /// Parameter projection for `List<T extends IInspectable>` or `List<Object?>`

--- a/packages/winrtgen/lib/src/projections/types/uri.dart
+++ b/packages/winrtgen/lib/src/projections/types/uri.dart
@@ -22,6 +22,7 @@ bool _methodBelongsToUriRuntimeClass(Method method) => [
     ].contains(method.parent.name);
 
 mixin _UriMixin on MethodProjection {
+  @override
   bool get isNullable {
     // Factory interface methods (constructors) cannot return null.
     final factoryInterfacePattern = RegExp(r'^I\w+Factory\d{0,2}$');
@@ -111,6 +112,7 @@ class UriSetterProjection extends SetterProjection {
 class UriParameterProjection extends ParameterProjection {
   UriParameterProjection(super.parameter);
 
+  @override
   bool get isNullable =>
       !method.parent.name.endsWith('IIterator`1') &&
       !method.parent.name.endsWith('IVector`1') &&

--- a/packages/winrtgen/test/goldens/icalendar.golden
+++ b/packages/winrtgen/test/goldens/icalendar.golden
@@ -1904,6 +1904,7 @@ class ICalendar extends IInspectable {
 
   int compare(Calendar? other) {
     final retValuePtr = calloc<Int32>();
+    final otherPtr = other == null ? nullptr : other.ptr.ref.lpVtbl;
 
     try {
       final hr = ptr.ref.vtable
@@ -1916,8 +1917,8 @@ class ICalendar extends IInspectable {
               .value
               .asFunction<
                   int Function(LPVTBL lpVtbl, LPVTBL other,
-                      Pointer<Int32> retValuePtr)>()(ptr.ref.lpVtbl,
-          other == null ? nullptr : other.ptr.ref.lpVtbl, retValuePtr);
+                      Pointer<Int32> retValuePtr)>()(
+          ptr.ref.lpVtbl, otherPtr, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1955,6 +1956,8 @@ class ICalendar extends IInspectable {
   }
 
   void copyTo(Calendar? other) {
+    final otherPtr = other == null ? nullptr : other.ptr.ref.lpVtbl;
+
     final hr = ptr.ref.vtable
             .elementAt(95)
             .cast<
@@ -1963,7 +1966,7 @@ class ICalendar extends IInspectable {
                         HRESULT Function(LPVTBL lpVtbl, LPVTBL other)>>>()
             .value
             .asFunction<int Function(LPVTBL lpVtbl, LPVTBL other)>()(
-        ptr.ref.lpVtbl, other == null ? nullptr : other.ptr.ref.lpVtbl);
+        ptr.ref.lpVtbl, otherPtr);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/packages/winrtgen/test/projections/parameter_test.dart
+++ b/packages/winrtgen/test/projections/parameter_test.dart
@@ -33,10 +33,12 @@ void main() {
       final parameter = methodProjection.parameters.first;
       expect(parameter, isA<ObjectParameterProjection>());
       expect(parameter.type, equals('Calendar?'));
-      expect(parameter.preamble, isEmpty);
+      expect(
+          parameter.preamble,
+          equals(
+              'final otherPtr = other == null ? nullptr : other.ptr.ref.lpVtbl;'));
       expect(parameter.postamble, isEmpty);
-      expect(parameter.localIdentifier,
-          equals('other == null ? nullptr : other.ptr.ref.lpVtbl'));
+      expect(parameter.localIdentifier, equals('otherPtr'));
     });
 
     test('projects DateTime', () {
@@ -117,12 +119,28 @@ void main() {
       final parameter = methodProjection.parameters.first;
       expect(parameter, isA<ObjectParameterProjection>());
       expect(parameter.type, equals('IStorageFile?'));
-      expect(parameter.preamble, isEmpty);
-      expect(parameter.postamble, isEmpty);
       expect(
-          parameter.localIdentifier,
+          parameter.preamble,
           equals(
-              'fileToReplace == null ? nullptr : fileToReplace.ptr.ref.lpVtbl'));
+              'final fileToReplacePtr = fileToReplace == null ? nullptr : fileToReplace.ptr.ref.lpVtbl;'));
+      expect(parameter.postamble, isEmpty);
+      expect(parameter.localIdentifier, equals('fileToReplacePtr'));
+    });
+
+    test('projects IIterable<IKeyValuePair<String, Object?>>?', () {
+      final methodProjection = MethodProjection.fromTypeAndMethodName(
+          'Windows.Storage.FileProperties.IStorageItemExtraProperties',
+          'SavePropertiesAsync');
+      final parameter = methodProjection.parameters.first;
+      expect(parameter, isA<ObjectParameterProjection>());
+      expect(
+          parameter.type, equals('IIterable<IKeyValuePair<String, Object?>>?'));
+      expect(
+          parameter.preamble,
+          equals(
+              "final propertiesToSavePtr = propertiesToSave == null ? nullptr : IInspectable(propertiesToSave.toInterface('{fe2f3d47-5d47-5499-8374-430c7cda0204}')).ptr.ref.lpVtbl;"));
+      expect(parameter.postamble, equals('propertiesToSave?.release();'));
+      expect(parameter.localIdentifier, equals('propertiesToSavePtr'));
     });
 
     test('projects IReference<BluetoothLEAdvertisementFlags?>', () {
@@ -159,10 +177,10 @@ void main() {
       final parameter = methodProjection.parameters.last;
       expect(parameter, isA<ObjectParameterProjection>());
       expect(parameter.type, equals('Object?'));
-      expect(parameter.preamble, isEmpty);
+      expect(parameter.preamble,
+          equals('final valuePtr = value?.intoBox().ref.lpVtbl ?? nullptr;'));
       expect(parameter.postamble, isEmpty);
-      expect(parameter.localIdentifier,
-          equals('value?.intoBox().ref.lpVtbl ?? nullptr'));
+      expect(parameter.localIdentifier, equals('valuePtr'));
     });
 
     test('projects pointer', () {


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

WinRT APIs that take `IIterable` as a parameter often expect the `IIterable` objects directly. This means if we pass objects like `IVector` and `IMap` to these APIs, we would get an Exception.

This PR, cast objects to appropriate `IIterable` interfaces on `IIterable` parameters to fix this. Ideally, we should expose `IIterable` parameters as `List` or `Map` depending on the type argument. However, in order to do that, we have to implement collection interfaces first.

 ## Related Issue

<!--- Link the relevant issue here -->

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
