### PR TITLE
Fix projection types of DateTime and Duration

### DIFF
--- a/packages/windows_devices/lib/src/geolocation/icivicaddress.dart
+++ b/packages/windows_devices/lib/src/geolocation/icivicaddress.dart
@@ -128,7 +128,7 @@ class ICivicAddress extends IInspectable {
   }
 
   DateTime get timestamp {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -137,10 +137,10 @@ class ICivicAddress extends IInspectable {
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);

--- a/packages/windows_devices/lib/src/geolocation/igeocoordinate.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeocoordinate.dart
@@ -232,7 +232,7 @@ class IGeocoordinate extends IInspectable {
   }
 
   DateTime get timestamp {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -241,10 +241,10 @@ class IGeocoordinate extends IInspectable {
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);

--- a/packages/windows_devices/lib/src/geolocation/igeolocator.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeolocator.dart
@@ -211,8 +211,8 @@ class IGeolocator extends IInspectable {
             .cast<
                 Pointer<
                     NativeFunction<
-                        HRESULT Function(LPVTBL lpVtbl, Uint64 maximumAge,
-                            Uint64 timeout, Pointer<COMObject> retValuePtr)>>>()
+                        HRESULT Function(LPVTBL lpVtbl, Int64 maximumAge,
+                            Int64 timeout, Pointer<COMObject> retValuePtr)>>>()
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, int maximumAge, int timeout,

--- a/packages/windows_devices/lib/src/geolocation/igeolocatorstatics.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeolocatorstatics.dart
@@ -72,7 +72,7 @@ class IGeolocatorStatics extends IInspectable {
             .cast<
                 Pointer<
                     NativeFunction<
-                        HRESULT Function(LPVTBL lpVtbl, Uint64 startTime,
+                        HRESULT Function(LPVTBL lpVtbl, Int64 startTime,
                             Pointer<COMObject> retValuePtr)>>>()
             .value
             .asFunction<
@@ -105,22 +105,18 @@ class IGeolocatorStatics extends IInspectable {
         startTime.difference(DateTime.utc(1601, 01, 01)).inMicroseconds * 10;
     final durationDuration = duration.inMicroseconds * 10;
 
-    final hr =
-        ptr.ref.vtable
-                .elementAt(8)
-                .cast<
-                    Pointer<
-                        NativeFunction<
-                            HRESULT Function(
-                                LPVTBL lpVtbl,
-                                Uint64 startTime,
-                                Uint64 duration,
-                                Pointer<COMObject> retValuePtr)>>>()
-                .value
-                .asFunction<
-                    int Function(LPVTBL lpVtbl, int startTime, int duration,
-                        Pointer<COMObject> retValuePtr)>()(
-            ptr.ref.lpVtbl, startTimeDateTime, durationDuration, retValuePtr);
+    final hr = ptr.ref.vtable
+            .elementAt(8)
+            .cast<
+                Pointer<
+                    NativeFunction<
+                        HRESULT Function(LPVTBL lpVtbl, Int64 startTime,
+                            Int64 duration, Pointer<COMObject> retValuePtr)>>>()
+            .value
+            .asFunction<
+                int Function(LPVTBL lpVtbl, int startTime, int duration,
+                    Pointer<COMObject> retValuePtr)>()(
+        ptr.ref.lpVtbl, startTimeDateTime, durationDuration, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);

--- a/packages/windows_devices/lib/src/sensors/ipedometerreading.dart
+++ b/packages/windows_devices/lib/src/sensors/ipedometerreading.dart
@@ -79,7 +79,7 @@ class IPedometerReading extends IInspectable {
   }
 
   DateTime get timestamp {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -88,10 +88,10 @@ class IPedometerReading extends IInspectable {
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
@@ -104,7 +104,7 @@ class IPedometerReading extends IInspectable {
   }
 
   Duration get cumulativeStepsDuration {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -113,10 +113,10 @@ class IPedometerReading extends IInspectable {
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);

--- a/packages/windows_foundation/lib/src/ipropertyvalue.dart
+++ b/packages/windows_foundation/lib/src/ipropertyvalue.dart
@@ -396,7 +396,7 @@ class IPropertyValue extends IInspectable {
   }
 
   DateTime getDateTime() {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -405,10 +405,10 @@ class IPropertyValue extends IInspectable {
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
@@ -421,7 +421,7 @@ class IPropertyValue extends IInspectable {
   }
 
   Duration getTimeSpan() {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -430,10 +430,10 @@ class IPropertyValue extends IInspectable {
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
@@ -912,7 +912,7 @@ class IPropertyValue extends IInspectable {
 
   void getDateTimeArray(List<DateTime> value) {
     final pValueSize = calloc<Uint32>();
-    final pArray = calloc<Pointer<Uint64>>();
+    final pArray = calloc<Pointer<Int64>>();
 
     final hr =
         ptr.ref.vtable
@@ -923,11 +923,11 @@ class IPropertyValue extends IInspectable {
                             HRESULT Function(
                                 LPVTBL lpVtbl,
                                 Pointer<Uint32> valueSize,
-                                Pointer<Pointer<Uint64>> value)>>>()
+                                Pointer<Pointer<Int64>> value)>>>()
                 .value
                 .asFunction<
                     int Function(LPVTBL lpVtbl, Pointer<Uint32> valueSize,
-                        Pointer<Pointer<Uint64>> value)>()(
+                        Pointer<Pointer<Int64>> value)>()(
             ptr.ref.lpVtbl, pValueSize, pArray);
 
     if (FAILED(hr)) throw WindowsException(hr);
@@ -940,7 +940,7 @@ class IPropertyValue extends IInspectable {
 
   void getTimeSpanArray(List<Duration> value) {
     final pValueSize = calloc<Uint32>();
-    final pArray = calloc<Pointer<Uint64>>();
+    final pArray = calloc<Pointer<Int64>>();
 
     final hr =
         ptr.ref.vtable
@@ -951,11 +951,11 @@ class IPropertyValue extends IInspectable {
                             HRESULT Function(
                                 LPVTBL lpVtbl,
                                 Pointer<Uint32> valueSize,
-                                Pointer<Pointer<Uint64>> value)>>>()
+                                Pointer<Pointer<Int64>> value)>>>()
                 .value
                 .asFunction<
                     int Function(LPVTBL lpVtbl, Pointer<Uint32> valueSize,
-                        Pointer<Pointer<Uint64>> value)>()(
+                        Pointer<Pointer<Int64>> value)>()(
             ptr.ref.lpVtbl, pValueSize, pArray);
 
     if (FAILED(hr)) throw WindowsException(hr);

--- a/packages/windows_foundation/lib/src/ipropertyvaluestatics.dart
+++ b/packages/windows_foundation/lib/src/ipropertyvaluestatics.dart
@@ -408,7 +408,7 @@ class IPropertyValueStatics extends IInspectable {
             .cast<
                 Pointer<
                     NativeFunction<
-                        HRESULT Function(LPVTBL lpVtbl, Uint64 value,
+                        HRESULT Function(LPVTBL lpVtbl, Int64 value,
                             Pointer<COMObject> retValuePtr)>>>()
             .value
             .asFunction<
@@ -433,7 +433,7 @@ class IPropertyValueStatics extends IInspectable {
             .cast<
                 Pointer<
                     NativeFunction<
-                        HRESULT Function(LPVTBL lpVtbl, Uint64 value,
+                        HRESULT Function(LPVTBL lpVtbl, Int64 value,
                             Pointer<COMObject> retValuePtr)>>>()
             .value
             .asFunction<
@@ -1011,7 +1011,7 @@ class IPropertyValueStatics extends IInspectable {
   IPropertyValue createDateTimeArray(List<DateTime> value) {
     final retValuePtr = calloc<COMObject>();
 
-    final pArray = calloc<Uint64>(value.length);
+    final pArray = calloc<Int64>(value.length);
     for (var i = 0; i < value.length; i++) {
       pArray[i] = value
               .elementAt(i)
@@ -1028,12 +1028,12 @@ class IPropertyValueStatics extends IInspectable {
                         HRESULT Function(
                             LPVTBL lpVtbl,
                             Uint32 valueSize,
-                            Pointer<Uint64> value,
+                            Pointer<Int64> value,
                             Pointer<COMObject> retValuePtr)>>>()
             .value
             .asFunction<
-                int Function(LPVTBL lpVtbl, int valueSize,
-                    Pointer<Uint64> value, Pointer<COMObject> retValuePtr)>()(
+                int Function(LPVTBL lpVtbl, int valueSize, Pointer<Int64> value,
+                    Pointer<COMObject> retValuePtr)>()(
         ptr.ref.lpVtbl, value.length, pArray, retValuePtr);
 
     if (FAILED(hr)) {
@@ -1049,7 +1049,7 @@ class IPropertyValueStatics extends IInspectable {
   IPropertyValue createTimeSpanArray(List<Duration> value) {
     final retValuePtr = calloc<COMObject>();
 
-    final pArray = calloc<Uint64>(value.length);
+    final pArray = calloc<Int64>(value.length);
     for (var i = 0; i < value.length; i++) {
       pArray[i] = value.elementAt(i).inMicroseconds * 10;
     }
@@ -1062,12 +1062,12 @@ class IPropertyValueStatics extends IInspectable {
                         HRESULT Function(
                             LPVTBL lpVtbl,
                             Uint32 valueSize,
-                            Pointer<Uint64> value,
+                            Pointer<Int64> value,
                             Pointer<COMObject> retValuePtr)>>>()
             .value
             .asFunction<
-                int Function(LPVTBL lpVtbl, int valueSize,
-                    Pointer<Uint64> value, Pointer<COMObject> retValuePtr)>()(
+                int Function(LPVTBL lpVtbl, int valueSize, Pointer<Int64> value,
+                    Pointer<COMObject> retValuePtr)>()(
         ptr.ref.lpVtbl, value.length, pArray, retValuePtr);
 
     if (FAILED(hr)) {

--- a/packages/windows_foundation/lib/src/ireference_part.dart
+++ b/packages/windows_foundation/lib/src/ireference_part.dart
@@ -48,7 +48,7 @@ class _IReferenceDateTime extends IReference<DateTime?> {
   DateTime? get value {
     if (_isNull) return null;
 
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -57,10 +57,10 @@ class _IReferenceDateTime extends IReference<DateTime?> {
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
@@ -111,7 +111,7 @@ class _IReferenceDuration extends IReference<Duration?> {
   Duration? get value {
     if (_isNull) return null;
 
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -120,10 +120,10 @@ class _IReferenceDuration extends IReference<Duration?> {
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);

--- a/packages/windows_globalization/lib/src/icalendar.dart
+++ b/packages/windows_globalization/lib/src/icalendar.dart
@@ -238,7 +238,7 @@ class ICalendar extends IInspectable {
   }
 
   DateTime getDateTime() {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -247,10 +247,10 @@ class ICalendar extends IInspectable {
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
@@ -267,14 +267,14 @@ class ICalendar extends IInspectable {
         value.difference(DateTime.utc(1601, 01, 01)).inMicroseconds * 10;
 
     final hr = ptr.ref.vtable
-            .elementAt(17)
-            .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(LPVTBL lpVtbl, Uint64 value)>>>()
-            .value
-            .asFunction<int Function(LPVTBL lpVtbl, int value)>()(
-        ptr.ref.lpVtbl, valueDateTime);
+        .elementAt(17)
+        .cast<
+            Pointer<
+                NativeFunction<HRESULT Function(LPVTBL lpVtbl, Int64 value)>>>()
+        .value
+        .asFunction<
+            int Function(
+                LPVTBL lpVtbl, int value)>()(ptr.ref.lpVtbl, valueDateTime);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -1939,7 +1939,7 @@ class ICalendar extends IInspectable {
               .cast<
                   Pointer<
                       NativeFunction<
-                          HRESULT Function(LPVTBL lpVtbl, Uint64 other,
+                          HRESULT Function(LPVTBL lpVtbl, Int64 other,
                               Pointer<Int32> retValuePtr)>>>()
               .value
               .asFunction<

--- a/packages/windows_networking/lib/src/connectivity/iconnectionprofile.dart
+++ b/packages/windows_networking/lib/src/connectivity/iconnectionprofile.dart
@@ -208,8 +208,8 @@ class IConnectionProfile extends IInspectable {
             .cast<
                 Pointer<
                     NativeFunction<
-                        HRESULT Function(LPVTBL lpVtbl, Uint64 StartTime,
-                            Uint64 EndTime, Pointer<COMObject> retValuePtr)>>>()
+                        HRESULT Function(LPVTBL lpVtbl, Int64 StartTime,
+                            Int64 EndTime, Pointer<COMObject> retValuePtr)>>>()
             .value
             .asFunction<
                 int Function(LPVTBL lpVtbl, int StartTime, int EndTime,
@@ -244,8 +244,8 @@ class IConnectionProfile extends IInspectable {
                     NativeFunction<
                         HRESULT Function(
                             LPVTBL lpVtbl,
-                            Uint64 StartTime,
-                            Uint64 EndTime,
+                            Int64 StartTime,
+                            Int64 EndTime,
                             Uint32 States,
                             Pointer<COMObject> retValuePtr)>>>()
             .value

--- a/packages/windows_networking/lib/src/connectivity/iconnectionprofile2.dart
+++ b/packages/windows_networking/lib/src/connectivity/iconnectionprofile2.dart
@@ -248,8 +248,8 @@ class IConnectionProfile2 extends IInspectable {
                     NativeFunction<
                         HRESULT Function(
                             LPVTBL lpVtbl,
-                            Uint64 startTime,
-                            Uint64 endTime,
+                            Int64 startTime,
+                            Int64 endTime,
                             Int32 granularity,
                             NetworkUsageStates states,
                             Pointer<COMObject> retValuePtr)>>>()
@@ -301,8 +301,8 @@ class IConnectionProfile2 extends IInspectable {
                     NativeFunction<
                         HRESULT Function(
                             LPVTBL lpVtbl,
-                            Uint64 startTime,
-                            Uint64 endTime,
+                            Int64 startTime,
+                            Int64 endTime,
                             NetworkUsageStates states,
                             Pointer<COMObject> retValuePtr)>>>()
             .value

--- a/packages/windows_networking/lib/src/connectivity/iconnectionprofile3.dart
+++ b/packages/windows_networking/lib/src/connectivity/iconnectionprofile3.dart
@@ -47,8 +47,8 @@ class IConnectionProfile3 extends IInspectable {
                     NativeFunction<
                         HRESULT Function(
                             LPVTBL lpVtbl,
-                            Uint64 startTime,
-                            Uint64 endTime,
+                            Int64 startTime,
+                            Int64 endTime,
                             NetworkUsageStates states,
                             Pointer<COMObject> retValuePtr)>>>()
             .value

--- a/packages/windows_networking/lib/src/connectivity/iconnectionprofile4.dart
+++ b/packages/windows_networking/lib/src/connectivity/iconnectionprofile4.dart
@@ -47,8 +47,8 @@ class IConnectionProfile4 extends IInspectable {
                     NativeFunction<
                         HRESULT Function(
                             LPVTBL lpVtbl,
-                            Uint64 startTime,
-                            Uint64 endTime,
+                            Int64 startTime,
+                            Int64 endTime,
                             NetworkUsageStates states,
                             Pointer<COMObject> retValuePtr)>>>()
             .value

--- a/packages/windows_networking/lib/src/connectivity/iconnectivityinterval.dart
+++ b/packages/windows_networking/lib/src/connectivity/iconnectivityinterval.dart
@@ -29,7 +29,7 @@ class IConnectivityInterval extends IInspectable {
           interface.toInterface(IID_IConnectivityInterval));
 
   DateTime get startTime {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -38,10 +38,10 @@ class IConnectivityInterval extends IInspectable {
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
@@ -54,7 +54,7 @@ class IConnectivityInterval extends IInspectable {
   }
 
   Duration get connectionDuration {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -63,10 +63,10 @@ class IConnectivityInterval extends IInspectable {
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);

--- a/packages/windows_networking/lib/src/connectivity/idataplanusage.dart
+++ b/packages/windows_networking/lib/src/connectivity/idataplanusage.dart
@@ -52,7 +52,7 @@ class IDataPlanUsage extends IInspectable {
   }
 
   DateTime get lastSyncTime {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -61,10 +61,10 @@ class IDataPlanUsage extends IInspectable {
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);

--- a/packages/windows_networking/lib/src/connectivity/inetworkusage.dart
+++ b/packages/windows_networking/lib/src/connectivity/inetworkusage.dart
@@ -76,7 +76,7 @@ class INetworkUsage extends IInspectable {
   }
 
   Duration get connectionDuration {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -85,10 +85,10 @@ class INetworkUsage extends IInspectable {
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);

--- a/packages/windows_storage/lib/src/fileproperties/ibasicproperties.dart
+++ b/packages/windows_storage/lib/src/fileproperties/ibasicproperties.dart
@@ -53,7 +53,7 @@ class IBasicProperties extends IInspectable {
   }
 
   DateTime get dateModified {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -62,10 +62,10 @@ class IBasicProperties extends IInspectable {
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
@@ -78,7 +78,7 @@ class IBasicProperties extends IInspectable {
   }
 
   DateTime get itemDate {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -87,10 +87,10 @@ class IBasicProperties extends IInspectable {
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);

--- a/packages/windows_storage/lib/src/fileproperties/iimageproperties.dart
+++ b/packages/windows_storage/lib/src/fileproperties/iimageproperties.dart
@@ -95,7 +95,7 @@ class IImageProperties extends IInspectable
   }
 
   DateTime get dateTaken {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -104,10 +104,10 @@ class IImageProperties extends IInspectable
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
@@ -124,14 +124,14 @@ class IImageProperties extends IInspectable
         value.difference(DateTime.utc(1601, 01, 01)).inMicroseconds * 10;
 
     final hr = ptr.ref.vtable
-            .elementAt(10)
-            .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(LPVTBL lpVtbl, Uint64 value)>>>()
-            .value
-            .asFunction<int Function(LPVTBL lpVtbl, int value)>()(
-        ptr.ref.lpVtbl, dateTimeOffset);
+        .elementAt(10)
+        .cast<
+            Pointer<
+                NativeFunction<HRESULT Function(LPVTBL lpVtbl, Int64 value)>>>()
+        .value
+        .asFunction<
+            int Function(
+                LPVTBL lpVtbl, int value)>()(ptr.ref.lpVtbl, dateTimeOffset);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }

--- a/packages/windows_storage/lib/src/fileproperties/imusicproperties.dart
+++ b/packages/windows_storage/lib/src/fileproperties/imusicproperties.dart
@@ -267,7 +267,7 @@ class IMusicProperties extends IInspectable
   }
 
   Duration get duration {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -276,10 +276,10 @@ class IMusicProperties extends IInspectable
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);

--- a/packages/windows_storage/lib/src/fileproperties/ivideoproperties.dart
+++ b/packages/windows_storage/lib/src/fileproperties/ivideoproperties.dart
@@ -143,7 +143,7 @@ class IVideoProperties extends IInspectable
   }
 
   Duration get duration {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -152,10 +152,10 @@ class IVideoProperties extends IInspectable
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);

--- a/packages/windows_storage/lib/src/istorageitem.dart
+++ b/packages/windows_storage/lib/src/istorageitem.dart
@@ -252,7 +252,7 @@ class IStorageItem extends IInspectable {
   }
 
   DateTime get dateCreated {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -261,10 +261,10 @@ class IStorageItem extends IInspectable {
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);

--- a/packages/windows_system/lib/src/power/ipowermanagerstatics.dart
+++ b/packages/windows_system/lib/src/power/ipowermanagerstatics.dart
@@ -283,7 +283,7 @@ class IPowerManagerStatics extends IInspectable {
   }
 
   Duration get remainingDischargeTime {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -292,10 +292,10 @@ class IPowerManagerStatics extends IInspectable {
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);

--- a/packages/windows_ui/lib/src/notifications/ischeduledtoastnotification.dart
+++ b/packages/windows_ui/lib/src/notifications/ischeduledtoastnotification.dart
@@ -59,7 +59,7 @@ class IScheduledToastNotification extends IInspectable {
   }
 
   DateTime get deliveryTime {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -68,10 +68,10 @@ class IScheduledToastNotification extends IInspectable {
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);

--- a/packages/windows_ui/lib/src/notifications/ischeduledtoastnotificationfactory.dart
+++ b/packages/windows_ui/lib/src/notifications/ischeduledtoastnotificationfactory.dart
@@ -39,21 +39,22 @@ class IScheduledToastNotificationFactory extends IInspectable {
     final deliveryTimeDateTime =
         deliveryTime.difference(DateTime.utc(1601, 01, 01)).inMicroseconds * 10;
 
-    final hr = ptr.ref.vtable
-            .elementAt(6)
-            .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(
-                            LPVTBL lpVtbl,
-                            LPVTBL content,
-                            Uint64 deliveryTime,
-                            Pointer<COMObject> retValuePtr)>>>()
-            .value
-            .asFunction<
-                int Function(LPVTBL lpVtbl, LPVTBL content, int deliveryTime,
-                    Pointer<COMObject> retValuePtr)>()(
-        ptr.ref.lpVtbl, contentPtr, deliveryTimeDateTime, retValuePtr);
+    final hr =
+        ptr.ref.vtable
+                .elementAt(6)
+                .cast<
+                    Pointer<
+                        NativeFunction<
+                            HRESULT Function(
+                                LPVTBL lpVtbl,
+                                LPVTBL content,
+                                Int64 deliveryTime,
+                                Pointer<COMObject> retValuePtr)>>>()
+                .value
+                .asFunction<
+                    int Function(LPVTBL lpVtbl, LPVTBL content,
+                        int deliveryTime, Pointer<COMObject> retValuePtr)>()(
+            ptr.ref.lpVtbl, contentPtr, deliveryTimeDateTime, retValuePtr);
 
     if (FAILED(hr)) {
       free(retValuePtr);
@@ -82,8 +83,8 @@ class IScheduledToastNotificationFactory extends IInspectable {
                         HRESULT Function(
                             LPVTBL lpVtbl,
                             LPVTBL content,
-                            Uint64 deliveryTime,
-                            Uint64 snoozeInterval,
+                            Int64 deliveryTime,
+                            Int64 snoozeInterval,
                             Uint32 maximumSnoozeCount,
                             Pointer<COMObject> retValuePtr)>>>()
             .value

--- a/packages/winrtgen/lib/src/projections/type.dart
+++ b/packages/winrtgen/lib/src/projections/type.dart
@@ -10,13 +10,13 @@ import '../models/models.dart';
 class TypeTuple {
   const TypeTuple(this.nativeType, this.dartType, {this.attribute});
 
-  /// The type, as represented in the native function (e.g. `Uint64`)
+  /// The type, as represented in the native function (e.g. `Int64`)
   final String nativeType;
 
   /// The type, as represented in the Dart function (e.g. `int`)
   final String dartType;
 
-  /// The type, as represented as a struct attribute (e.g. `@Uint64()`)
+  /// The type, as represented as a struct attribute (e.g. `@Int64()`)
   final String? attribute;
 }
 
@@ -41,13 +41,13 @@ const baseNativeMapping = <BaseType, TypeTuple>{
 const specialTypes = <String, TypeTuple>{
   'System.Guid': TypeTuple('GUID', 'GUID'),
   'Windows.Foundation.DateTime':
-      TypeTuple('Uint64', 'int', attribute: '@Uint64()'),
+      TypeTuple('Int64', 'int', attribute: '@Int64()'),
   'Windows.Foundation.EventRegistrationToken':
       TypeTuple('IntPtr', 'int', attribute: '@IntPtr()'),
   'Windows.Foundation.HResult':
       TypeTuple('Int32', 'int', attribute: '@Int32()'),
   'Windows.Foundation.TimeSpan':
-      TypeTuple('Uint64', 'int', attribute: '@Uint64()'),
+      TypeTuple('Int64', 'int', attribute: '@Int64()'),
 };
 
 class TypeProjection {
@@ -60,13 +60,13 @@ class TypeProjection {
   /// Whether this type belongs to a parameter.
   final bool isParameter;
 
-  /// The type, as represented in the native function (e.g. `Uint64`)
+  /// The type, as represented in the native function (e.g. `Int64`)
   String get nativeType => projection.nativeType;
 
   /// The type, as represented in the Dart function (e.g. `int`)
   String get dartType => projection.dartType;
 
-  /// The type, as represented as a struct attribute (e.g. `@Uint64()`)
+  /// The type, as represented as a struct attribute (e.g. `@Int64()`)
   String get attribute => projection.attribute ?? '';
 
   /// The projection type of this type (e.g. `ProjectionType.dateTime`).

--- a/packages/winrtgen/lib/src/projections/types/datetime.dart
+++ b/packages/winrtgen/lib/src/projections/types/datetime.dart
@@ -19,7 +19,7 @@ mixin _DateTimeMixin on MethodProjection {
   @override
   String get methodDeclaration => '''
   $methodHeader {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<${returnTypeProjection.nativeType}>();
     $parametersPreamble
 
     try {
@@ -88,7 +88,7 @@ class DateTimeListParameterProjection extends DefaultListParameterProjection {
 
   @override
   String get passArrayPreamble => '''
-    final pArray = calloc<Uint64>(value.length);
+    final pArray = calloc<Int64>(value.length);
     for (var i = 0; i < value.length; i++) {
       pArray[i] = value.elementAt(i)
           .difference(DateTime.utc(1601, 01, 01)).inMicroseconds * 10;

--- a/packages/winrtgen/lib/src/projections/types/duration.dart
+++ b/packages/winrtgen/lib/src/projections/types/duration.dart
@@ -12,10 +12,12 @@ mixin _DurationMixin on MethodProjection {
   @override
   String get returnType => 'Duration';
 
+  // In WinRT, Duration is represented as a time period expressed in
+  // 100-nanosecond units.
   @override
   String get methodDeclaration => '''
   $methodHeader {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<${returnTypeProjection.nativeType}>();
     $parametersPreamble
 
     try {
@@ -80,7 +82,7 @@ class DurationListParameterProjection extends DefaultListParameterProjection {
 
   @override
   String get passArrayPreamble => '''
-    final pArray = calloc<Uint64>(value.length);
+    final pArray = calloc<Int64>(value.length);
     for (var i = 0; i < value.length; i++) {
       pArray[i] = value.elementAt(i).inMicroseconds * 10;
     }''';

--- a/packages/winrtgen/test/goldens/icalendar.golden
+++ b/packages/winrtgen/test/goldens/icalendar.golden
@@ -238,7 +238,7 @@ class ICalendar extends IInspectable {
   }
 
   DateTime getDateTime() {
-    final retValuePtr = calloc<Uint64>();
+    final retValuePtr = calloc<Int64>();
 
     try {
       final hr = ptr.ref.vtable
@@ -247,10 +247,10 @@ class ICalendar extends IInspectable {
                   Pointer<
                       NativeFunction<
                           HRESULT Function(
-                              LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>>>()
+                              LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>>>()
               .value
               .asFunction<
-                  int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)>()(
+                  int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
@@ -267,14 +267,14 @@ class ICalendar extends IInspectable {
         value.difference(DateTime.utc(1601, 01, 01)).inMicroseconds * 10;
 
     final hr = ptr.ref.vtable
-            .elementAt(17)
-            .cast<
-                Pointer<
-                    NativeFunction<
-                        HRESULT Function(LPVTBL lpVtbl, Uint64 value)>>>()
-            .value
-            .asFunction<int Function(LPVTBL lpVtbl, int value)>()(
-        ptr.ref.lpVtbl, valueDateTime);
+        .elementAt(17)
+        .cast<
+            Pointer<
+                NativeFunction<HRESULT Function(LPVTBL lpVtbl, Int64 value)>>>()
+        .value
+        .asFunction<
+            int Function(
+                LPVTBL lpVtbl, int value)>()(ptr.ref.lpVtbl, valueDateTime);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
@@ -1939,7 +1939,7 @@ class ICalendar extends IInspectable {
               .cast<
                   Pointer<
                       NativeFunction<
-                          HRESULT Function(LPVTBL lpVtbl, Uint64 other,
+                          HRESULT Function(LPVTBL lpVtbl, Int64 other,
                               Pointer<Int32> retValuePtr)>>>()
               .value
               .asFunction<

--- a/packages/winrtgen/test/projections/getter_test.dart
+++ b/packages/winrtgen/test/projections/getter_test.dart
@@ -90,9 +90,9 @@ void main() {
       expect(
           projection.nativePrototype,
           equals(
-              'HRESULT Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)'));
+              'HRESULT Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)'));
       expect(projection.dartPrototype,
-          equals('int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)'));
+          equals('int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)'));
       expect(projection.methodHeader, equals('DateTime get dateModified'));
     });
 
@@ -136,9 +136,9 @@ void main() {
       expect(
           projection.nativePrototype,
           equals(
-              'HRESULT Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)'));
+              'HRESULT Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)'));
       expect(projection.dartPrototype,
-          equals('int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)'));
+          equals('int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)'));
       expect(projection.methodHeader,
           equals('Duration get remainingDischargeTime'));
     });

--- a/packages/winrtgen/test/projections/method_test.dart
+++ b/packages/winrtgen/test/projections/method_test.dart
@@ -74,9 +74,9 @@ void main() {
       expect(
           projection.nativePrototype,
           equals(
-              'HRESULT Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)'));
+              'HRESULT Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)'));
       expect(projection.dartPrototype,
-          equals('int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)'));
+          equals('int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)'));
       expect(projection.methodHeader, equals('DateTime getDateTime()'));
     });
 
@@ -102,9 +102,9 @@ void main() {
       expect(
           projection.nativePrototype,
           equals(
-              'HRESULT Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)'));
+              'HRESULT Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)'));
       expect(projection.dartPrototype,
-          equals('int Function(LPVTBL lpVtbl, Pointer<Uint64> retValuePtr)'));
+          equals('int Function(LPVTBL lpVtbl, Pointer<Int64> retValuePtr)'));
       expect(projection.methodHeader, equals('Duration getTimeSpan()'));
     });
 

--- a/packages/winrtgen/test/projections/setter_test.dart
+++ b/packages/winrtgen/test/projections/setter_test.dart
@@ -74,7 +74,7 @@ void main() {
           'Windows.Storage.FileProperties.ImageProperties', 'put_DateTaken');
       expect(projection, isA<DateTimeSetterProjection>());
       expect(projection.nativePrototype,
-          equals('HRESULT Function(LPVTBL lpVtbl, Uint64 value)'));
+          equals('HRESULT Function(LPVTBL lpVtbl, Int64 value)'));
       expect(projection.dartPrototype,
           equals('int Function(LPVTBL lpVtbl, int value)'));
       expect(projection.methodHeader, equals('set dateTaken(DateTime value)'));
@@ -109,7 +109,7 @@ void main() {
           'Windows.Media.Playback.MediaPlaybackSession', 'put_Position');
       expect(projection, isA<DurationSetterProjection>());
       expect(projection.nativePrototype,
-          equals('HRESULT Function(LPVTBL lpVtbl, Uint64 value)'));
+          equals('HRESULT Function(LPVTBL lpVtbl, Int64 value)'));
       expect(projection.dartPrototype,
           equals('int Function(LPVTBL lpVtbl, int value)'));
       expect(projection.methodHeader, equals('set position(Duration value)'));

--- a/packages/winrtgen/test/projections/type_test.dart
+++ b/packages/winrtgen/test/projections/type_test.dart
@@ -20,7 +20,7 @@ void main() {
           'Windows.Globalization.ICalendar', 'GetDateTime');
       final typeProjection = methodProjection.returnTypeProjection;
       expect(typeProjection.dartType, equals('int'));
-      expect(typeProjection.nativeType, equals('Uint64'));
+      expect(typeProjection.nativeType, equals('Int64'));
     });
 
     test('EventRegistrationToken types are projected correctly', () {
@@ -44,7 +44,7 @@ void main() {
           'Windows.Foundation.IPropertyValue', 'GetTimeSpan');
       final typeProjection = methodProjection.returnTypeProjection;
       expect(typeProjection.dartType, equals('int'));
-      expect(typeProjection.nativeType, equals('Uint64'));
+      expect(typeProjection.nativeType, equals('Int64'));
     });
   });
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

These were incorrectly projected as `Uint64` instead of `Int64`.

See [DateTime Struct](https://learn.microsoft.com/en-us/uwp/api/windows.foundation.datetime?view=winrt-22621) and [TimeSpan Struct](https://learn.microsoft.com/en-us/uwp/api/windows.foundation.timespan?view=winrt-22621).

## Related Issue

<!--- Link the relevant issue here -->

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
