### PR TITLE
Support `simpleArray` methods and getters

### DIFF
--- a/packages/winrtgen/lib/src/projections/getter.dart
+++ b/packages/winrtgen/lib/src/projections/getter.dart
@@ -20,12 +20,19 @@ abstract class GetterProjection extends PropertyProjection {
     switch (projectionType) {
       case ProjectionType.dartPrimitive:
         return DefaultGetterProjection(method, vtableOffset);
+      case ProjectionType.dartPrimitiveList:
+      case ProjectionType.structList:
+        return DefaultListGetterProjection(method, vtableOffset);
       case ProjectionType.dateTime:
         return DateTimeGetterProjection(method, vtableOffset);
+      case ProjectionType.dateTimeList:
+        return DateTimeListGetterProjection(method, vtableOffset);
       case ProjectionType.delegate:
         return DelegateGetterProjection(method, vtableOffset);
       case ProjectionType.duration:
         return DurationGetterProjection(method, vtableOffset);
+      case ProjectionType.durationList:
+        return DurationListGetterProjection(method, vtableOffset);
       case ProjectionType.enum_:
         return EnumGetterProjection(method, vtableOffset);
       case ProjectionType.genericEnum:
@@ -34,20 +41,28 @@ abstract class GetterProjection extends PropertyProjection {
         return GenericObjectGetterProjection(method, vtableOffset);
       case ProjectionType.guid:
         return GuidGetterProjection(method, vtableOffset);
+      case ProjectionType.guidList:
+        return GuidListGetterProjection(method, vtableOffset);
       case ProjectionType.map:
         return MapGetterProjection(method, vtableOffset);
       case ProjectionType.mapView:
         return MapViewGetterProjection(method, vtableOffset);
       case ProjectionType.object:
         return ObjectGetterProjection(method, vtableOffset);
+      case ProjectionType.objectList:
+        return ObjectListGetterProjection(method, vtableOffset);
       case ProjectionType.reference:
         return ReferenceGetterProjection(method, vtableOffset);
       case ProjectionType.string:
         return StringGetterProjection(method, vtableOffset);
+      case ProjectionType.stringList:
+        return StringListGetterProjection(method, vtableOffset);
       case ProjectionType.struct:
         return StructGetterProjection(method, vtableOffset);
       case ProjectionType.uri:
         return UriGetterProjection(method, vtableOffset);
+      case ProjectionType.uriList:
+        return UriListGetterProjection(method, vtableOffset);
       case ProjectionType.vector:
         return VectorGetterProjection(method, vtableOffset);
       case ProjectionType.vectorView:

--- a/packages/winrtgen/lib/src/projections/method.dart
+++ b/packages/winrtgen/lib/src/projections/method.dart
@@ -59,12 +59,19 @@ abstract class MethodProjection {
         return ObjectMethodProjection(method, vtableOffset);
       case ProjectionType.dartPrimitive:
         return DefaultMethodProjection(method, vtableOffset);
+      case ProjectionType.dartPrimitiveList:
+      case ProjectionType.structList:
+        return DefaultListMethodProjection(method, vtableOffset);
       case ProjectionType.dateTime:
         return DateTimeMethodProjection(method, vtableOffset);
+      case ProjectionType.dateTimeList:
+        return DateTimeListMethodProjection(method, vtableOffset);
       case ProjectionType.delegate:
         return DelegateMethodProjection(method, vtableOffset);
       case ProjectionType.duration:
         return DurationMethodProjection(method, vtableOffset);
+      case ProjectionType.durationList:
+        return DurationListMethodProjection(method, vtableOffset);
       case ProjectionType.enum_:
         return EnumMethodProjection(method, vtableOffset);
       case ProjectionType.genericEnum:
@@ -73,20 +80,28 @@ abstract class MethodProjection {
         return GenericObjectMethodProjection(method, vtableOffset);
       case ProjectionType.guid:
         return GuidMethodProjection(method, vtableOffset);
+      case ProjectionType.guidList:
+        return GuidListMethodProjection(method, vtableOffset);
       case ProjectionType.map:
         return MapMethodProjection(method, vtableOffset);
       case ProjectionType.mapView:
         return MapViewMethodProjection(method, vtableOffset);
       case ProjectionType.object:
         return ObjectMethodProjection(method, vtableOffset);
+      case ProjectionType.objectList:
+        return ObjectListMethodProjection(method, vtableOffset);
       case ProjectionType.reference:
         return ReferenceMethodProjection(method, vtableOffset);
       case ProjectionType.string:
         return StringMethodProjection(method, vtableOffset);
+      case ProjectionType.stringList:
+        return StringListMethodProjection(method, vtableOffset);
       case ProjectionType.struct:
         return StructMethodProjection(method, vtableOffset);
       case ProjectionType.uri:
         return UriMethodProjection(method, vtableOffset);
+      case ProjectionType.uriList:
+        return UriListMethodProjection(method, vtableOffset);
       case ProjectionType.vector:
         return VectorMethodProjection(method, vtableOffset);
       case ProjectionType.vectorView:
@@ -207,12 +222,14 @@ abstract class MethodProjection {
   String get identifiers => [
         'ptr.ref.lpVtbl',
         ...parameters.map((param) => param.localIdentifier),
+        if (returnTypeProjection.isSimpleArray) 'pValueSize',
         if (!returnTypeProjection.isVoid) 'retValuePtr',
       ].join(', ');
 
   String get nativeParams => [
         'LPVTBL lpVtbl',
         ...parameters.map((param) => param.ffiProjection),
+        if (returnTypeProjection.isSimpleArray) 'Pointer<Uint32> valueSize',
         if (!returnTypeProjection.isVoid)
           '${wrapWithPointer(returnTypeProjection.nativeType)} retValuePtr',
       ].join(', ');
@@ -220,6 +237,7 @@ abstract class MethodProjection {
   String get dartParams => [
         'LPVTBL lpVtbl',
         ...parameters.map((param) => param.dartProjection),
+        if (returnTypeProjection.isSimpleArray) 'Pointer<Uint32> valueSize',
         if (!returnTypeProjection.isVoid)
           '${wrapWithPointer(returnTypeProjection.nativeType)} retValuePtr',
       ].join(', ');

--- a/packages/winrtgen/lib/src/projections/types/datetime.dart
+++ b/packages/winrtgen/lib/src/projections/types/datetime.dart
@@ -40,6 +40,43 @@ class DateTimeGetterProjection extends GetterProjection with _DateTimeMixin {
   DateTimeGetterProjection(super.method, super.vtableOffset);
 }
 
+mixin _DateTimeListMixin on MethodProjection {
+  @override
+  String get returnType => 'List<DateTime>';
+
+  @override
+  String get methodDeclaration => '''
+  $methodHeader {
+    final pValueSize = calloc<Uint32>();
+    final retValuePtr = calloc<Pointer<Uint64>>();
+    $parametersPreamble
+
+    try {
+      ${ffiCall()}
+
+      return retValuePtr.value.toList(length: pValueSize.value).map((value) =>
+          DateTime.utc(1601, 01, 01).add(Duration(microseconds: value ~/ 10)));
+    } finally {
+      $parametersPostamble
+      free(pValueSize);
+      free(retValuePtr);
+    }
+  }
+''';
+}
+
+/// Method projection for methods that return `List<DateTime>`.
+class DateTimeListMethodProjection extends MethodProjection
+    with _DateTimeListMixin {
+  DateTimeListMethodProjection(super.method, super.vtableOffset);
+}
+
+/// Getter projection for `List<DateTime>` getters.
+class DateTimeListGetterProjection extends GetterProjection
+    with _DateTimeListMixin {
+  DateTimeListGetterProjection(super.method, super.vtableOffset);
+}
+
 /// Setter projection for `DateTime` setters.
 class DateTimeSetterProjection extends SetterProjection {
   DateTimeSetterProjection(super.method, super.vtableOffset);

--- a/packages/winrtgen/lib/src/projections/types/default.dart
+++ b/packages/winrtgen/lib/src/projections/types/default.dart
@@ -40,6 +40,47 @@ class DefaultGetterProjection extends GetterProjection with _DefaultMixin {
   DefaultGetterProjection(super.method, super.vtableOffset);
 }
 
+mixin _DefaultListMixin on MethodProjection {
+  late final typeArgProjection = TypeProjection(
+      method.returnType.typeIdentifier.isReferenceType
+          ? method.returnType.typeIdentifier.typeArg!.typeArg!
+          : method.returnType.typeIdentifier.typeArg!);
+
+  @override
+  String get returnType => 'List<${typeArgProjection.dartType}>';
+
+  @override
+  String get methodDeclaration => '''
+  $methodHeader {
+    final pValueSize = calloc<Uint32>();
+    final retValuePtr = calloc<${typeArgProjection.nativeType}>();
+    $parametersPreamble
+
+    try {
+      ${ffiCall()}
+
+      return retValuePtr.value.toList(length: pValueSize.value);
+    } finally {
+      $parametersPostamble
+      free(pValueSize);
+      free(retValuePtr);
+    }
+  }
+''';
+}
+
+/// Default method projection for methods that return `List`.
+class DefaultListMethodProjection extends MethodProjection
+    with _DefaultListMixin {
+  DefaultListMethodProjection(super.method, super.vtableOffset);
+}
+
+/// Default getter projection for `List` getters.
+class DefaultListGetterProjection extends GetterProjection
+    with _DefaultListMixin {
+  DefaultListGetterProjection(super.method, super.vtableOffset);
+}
+
 /// Default setter projection for setters.
 class DefaultSetterProjection extends SetterProjection {
   DefaultSetterProjection(super.method, super.vtableOffset);

--- a/packages/winrtgen/lib/src/projections/types/duration.dart
+++ b/packages/winrtgen/lib/src/projections/types/duration.dart
@@ -40,6 +40,44 @@ class DurationGetterProjection extends GetterProjection with _DurationMixin {
   DurationGetterProjection(super.method, super.vtableOffset);
 }
 
+mixin _DurationListMixin on MethodProjection {
+  @override
+  String get returnType => 'List<Duration>';
+
+  @override
+  String get methodDeclaration => '''
+  $methodHeader {
+    final pValueSize = calloc<Uint32>();
+    final retValuePtr = calloc<Pointer<Uint64>>();
+    $parametersPreamble
+
+    try {
+      ${ffiCall()}
+
+      return retValuePtr.value
+        .toList(length: pValueSize.value)
+        .map((value) => Duration(microseconds: value ~/ 10));
+    } finally {
+      $parametersPostamble
+      free(pValueSize);
+      free(retValuePtr);
+    }
+  }
+''';
+}
+
+/// Method projection for methods that return `List<Duration>`.
+class DurationListMethodProjection extends MethodProjection
+    with _DurationListMixin {
+  DurationListMethodProjection(super.method, super.vtableOffset);
+}
+
+/// Getter projection for `List<Duration>` getters.
+class DurationListGetterProjection extends GetterProjection
+    with _DurationListMixin {
+  DurationListGetterProjection(super.method, super.vtableOffset);
+}
+
 /// Setter projection for `Duration` setters.
 class DurationSetterProjection extends SetterProjection {
   DurationSetterProjection(super.method, super.vtableOffset);

--- a/packages/winrtgen/lib/src/projections/types/guid.dart
+++ b/packages/winrtgen/lib/src/projections/types/guid.dart
@@ -40,6 +40,40 @@ class GuidGetterProjection extends GetterProjection with _GuidMixin {
   GuidGetterProjection(super.method, super.vtableOffset);
 }
 
+mixin _GuidListMixin on MethodProjection {
+  @override
+  String get returnType => 'List<Guid>';
+
+  @override
+  String get methodDeclaration => '''
+  $methodHeader {
+    final pValueSize = calloc<Uint32>();
+    final retValuePtr = calloc<Pointer<GUID>>();
+    $parametersPreamble
+
+    try {
+      ${ffiCall()}
+
+      return retValuePtr.value.toList(length: pValueSize.value);
+    } finally {
+      $parametersPostamble
+      free(pValueSize);
+      free(retValuePtr);
+    }
+  }
+''';
+}
+
+/// Method projection for methods that return `List<Guid>`.
+class GuidListMethodProjection extends MethodProjection with _GuidListMixin {
+  GuidListMethodProjection(super.method, super.vtableOffset);
+}
+
+/// Getter projection for `List<Guid>` getters.
+class GuidListGetterProjection extends GetterProjection with _GuidListMixin {
+  GuidListGetterProjection(super.method, super.vtableOffset);
+}
+
 /// Setter projection for `Guid` setters.
 class GuidSetterProjection extends SetterProjection {
   GuidSetterProjection(super.method, super.vtableOffset);

--- a/packages/winrtgen/lib/src/projections/types/string.dart
+++ b/packages/winrtgen/lib/src/projections/types/string.dart
@@ -45,6 +45,42 @@ class StringGetterProjection extends GetterProjection with _StringMixin {
   StringGetterProjection(super.method, super.vtableOffset);
 }
 
+mixin _StringListMixin on MethodProjection {
+  @override
+  String get returnType => 'List<String>';
+
+  @override
+  String get methodDeclaration => '''
+  $methodHeader {
+    final pValueSize = calloc<Uint32>();
+    final retValuePtr = calloc<Pointer<HSTRING>>();
+    $parametersPreamble
+
+    try {
+      ${ffiCall()}
+
+      return retValuePtr.value.toList(length: pValueSize.value);
+    } finally {
+      $parametersPostamble
+      free(pValueSize);
+      free(retValuePtr);
+    }
+  }
+''';
+}
+
+/// Method projection for methods that return `List<String>`.
+class StringListMethodProjection extends MethodProjection
+    with _StringListMixin {
+  StringListMethodProjection(super.method, super.vtableOffset);
+}
+
+/// Getter projection for `List<String>` getters.
+class StringListGetterProjection extends GetterProjection
+    with _StringListMixin {
+  StringListGetterProjection(super.method, super.vtableOffset);
+}
+
 /// Setter projection for `String` setters.
 class StringSetterProjection extends SetterProjection {
   StringSetterProjection(super.method, super.vtableOffset);

--- a/packages/winrtgen/lib/src/projections/types/uri.dart
+++ b/packages/winrtgen/lib/src/projections/types/uri.dart
@@ -88,6 +88,42 @@ class UriGetterProjection extends GetterProjection with _UriMixin {
   UriGetterProjection(super.method, super.vtableOffset);
 }
 
+mixin _UriListMixin on MethodProjection {
+  @override
+  String get returnType => 'List<Uri>';
+
+  @override
+  String get methodDeclaration => '''
+  $methodHeader {
+    final pValueSize = calloc<Uint32>();
+    final retValuePtr = calloc<Pointer<COMObject>>();
+    $parametersPreamble
+
+    try {
+      ${ffiCall()}
+
+      return retValuePtr.value
+        .toList(winrt_uri.Uri.fromRawPointer, length: pValueSize.value)
+        .map((winrtUri) => Uri.parse(winrtUri.toString()));
+    } finally {
+      $parametersPostamble
+      free(pValueSize);
+      free(retValuePtr);
+    }
+  }
+''';
+}
+
+/// Method projection for methods that return `List<Uri>`.
+class UriListMethodProjection extends MethodProjection with _UriListMixin {
+  UriListMethodProjection(super.method, super.vtableOffset);
+}
+
+/// Getter projection for `List<Uri>` getters.
+class UriListGetterProjection extends GetterProjection with _UriListMixin {
+  UriListGetterProjection(super.method, super.vtableOffset);
+}
+
 /// Setter projection for `Uri` setters.
 class UriSetterProjection extends SetterProjection {
   UriSetterProjection(super.method, super.vtableOffset);

--- a/packages/winrtgen/test/projections/getter_test.dart
+++ b/packages/winrtgen/test/projections/getter_test.dart
@@ -312,6 +312,23 @@ void main() {
           contains('return IPropertyValue.fromRawPointer(retValuePtr).value;'));
     });
 
+    test('projects List<String>', () {
+      final projection = GetterProjection.fromTypeAndMethodName(
+          'Windows.ApplicationModel.AppInfo', 'get_SupportedFileExtensions');
+      expect(projection, isA<StringListGetterProjection>());
+      expect(projection.returnType, equals('List<String>'));
+      expect(
+          projection.nativePrototype,
+          equals(
+              'HRESULT Function(LPVTBL lpVtbl, Pointer<Uint32> valueSize, Pointer<IntPtr> retValuePtr)'));
+      expect(
+          projection.dartPrototype,
+          equals(
+              'int Function(LPVTBL lpVtbl, Pointer<Uint32> valueSize, Pointer<IntPtr> retValuePtr)'));
+      expect(projection.methodHeader,
+          equals('List<String> get supportedFileExtensions'));
+    });
+
     test('projects String', () {
       final projection = GetterProjection.fromTypeAndMethodName(
           'Windows.Globalization.ICalendar', 'get_NumeralSystem');

--- a/packages/winrtgen/test/projections/getter_test.dart
+++ b/packages/winrtgen/test/projections/getter_test.dart
@@ -8,11 +8,15 @@ import 'package:test/test.dart';
 import 'package:win32/win32.dart';
 import 'package:winrtgen/winrtgen.dart';
 
+import '../helpers.dart';
+
 void main() {
   if (!isWindowsRuntimeAvailable()) {
     print('Skipping tests because Windows Runtime is not available.');
     return;
   }
+
+  final windowsBuildNumber = getWindowsBuildNumber();
 
   group('GetterProjection', () {
     test('projects something', () {
@@ -312,22 +316,24 @@ void main() {
           contains('return IPropertyValue.fromRawPointer(retValuePtr).value;'));
     });
 
-    test('projects List<String>', () {
-      final projection = GetterProjection.fromTypeAndMethodName(
-          'Windows.ApplicationModel.AppInfo', 'get_SupportedFileExtensions');
-      expect(projection, isA<StringListGetterProjection>());
-      expect(projection.returnType, equals('List<String>'));
-      expect(
-          projection.nativePrototype,
-          equals(
-              'HRESULT Function(LPVTBL lpVtbl, Pointer<Uint32> valueSize, Pointer<IntPtr> retValuePtr)'));
-      expect(
-          projection.dartPrototype,
-          equals(
-              'int Function(LPVTBL lpVtbl, Pointer<Uint32> valueSize, Pointer<IntPtr> retValuePtr)'));
-      expect(projection.methodHeader,
-          equals('List<String> get supportedFileExtensions'));
-    });
+    if (windowsBuildNumber >= 20348) {
+      test('projects List<String>', () {
+        final projection = GetterProjection.fromTypeAndMethodName(
+            'Windows.ApplicationModel.AppInfo', 'get_SupportedFileExtensions');
+        expect(projection, isA<StringListGetterProjection>());
+        expect(projection.returnType, equals('List<String>'));
+        expect(
+            projection.nativePrototype,
+            equals(
+                'HRESULT Function(LPVTBL lpVtbl, Pointer<Uint32> valueSize, Pointer<IntPtr> retValuePtr)'));
+        expect(
+            projection.dartPrototype,
+            equals(
+                'int Function(LPVTBL lpVtbl, Pointer<Uint32> valueSize, Pointer<IntPtr> retValuePtr)'));
+        expect(projection.methodHeader,
+            equals('List<String> get supportedFileExtensions'));
+      });
+    }
 
     test('projects String', () {
       final projection = GetterProjection.fromTypeAndMethodName(


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

Adds support for methods/getters whose return type is `simpleArray` (exposed as `List`).

## Related Issue

<!--- Link the relevant issue here -->

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
