### PR TITLE
Overload some operators in collection interfaces

### DIFF
--- a/packages/windows_data/lib/src/json/jsonarray.dart
+++ b/packages/windows_data/lib/src/json/jsonarray.dart
@@ -134,6 +134,15 @@ class JsonArray extends IInspectable
   @override
   List<IJsonValue> toList() => _iVector.toList();
 
+  @override
+  IJsonValue operator [](int index) => _iVector[index];
+
+  @override
+  void operator []=(int index, IJsonValue value) => _iVector[index] = value;
+
+  @override
+  List<IJsonValue> operator +(List<IJsonValue> other) => toList() + other;
+
   late final _iStringable = IStringable.from(this);
 
   @override

--- a/packages/windows_data/lib/src/json/jsonobject.dart
+++ b/packages/windows_data/lib/src/json/jsonobject.dart
@@ -129,6 +129,12 @@ class JsonObject extends IInspectable
   @override
   Map<String, IJsonValue?> toMap() => _iMap.toMap();
 
+  @override
+  IJsonValue? operator [](String key) => _iMap[key];
+
+  @override
+  void operator []=(String key, IJsonValue? value) => _iMap[key] = value;
+
   late final _iJsonObjectWithDefaultValues =
       IJsonObjectWithDefaultValues.from(this);
 

--- a/packages/windows_data/lib/src/xml/dom/ixmlnamednodemap.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmlnamednodemap.dart
@@ -296,4 +296,10 @@ class IXmlNamedNodeMap extends IInspectable
 
   @override
   List<IXmlNode> toList() => _iVectorView.toList();
+
+  @override
+  IXmlNode operator [](int index) => _iVectorView[index];
+
+  @override
+  List<IXmlNode> operator +(List<IXmlNode> other) => toList() + other;
 }

--- a/packages/windows_data/lib/src/xml/dom/ixmlnodelist.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmlnodelist.dart
@@ -106,4 +106,10 @@ class IXmlNodeList extends IInspectable
 
   @override
   List<IXmlNode> toList() => _iVectorView.toList();
+
+  @override
+  IXmlNode operator [](int index) => _iVectorView[index];
+
+  @override
+  List<IXmlNode> operator +(List<IXmlNode> other) => toList() + other;
 }

--- a/packages/windows_data/lib/src/xml/dom/xmlnamednodemap.dart
+++ b/packages/windows_data/lib/src/xml/dom/xmlnamednodemap.dart
@@ -80,4 +80,10 @@ class XmlNamedNodeMap extends IInspectable
 
   @override
   List<IXmlNode> toList() => _iVectorView.toList();
+
+  @override
+  IXmlNode operator [](int index) => _iVectorView[index];
+
+  @override
+  List<IXmlNode> operator +(List<IXmlNode> other) => toList() + other;
 }

--- a/packages/windows_data/lib/src/xml/dom/xmlnodelist.dart
+++ b/packages/windows_data/lib/src/xml/dom/xmlnodelist.dart
@@ -57,4 +57,10 @@ class XmlNodeList extends IInspectable
 
   @override
   List<IXmlNode> toList() => _iVectorView.toList();
+
+  @override
+  IXmlNode operator [](int index) => _iVectorView[index];
+
+  @override
+  List<IXmlNode> operator +(List<IXmlNode> other) => toList() + other;
 }

--- a/packages/windows_data/test/collections_test.dart
+++ b/packages/windows_data/test/collections_test.dart
@@ -160,5 +160,32 @@ void main() {
       expect(current.value?.getString(), equals('strVal'));
       expect(iterator.moveNext(), isFalse);
     });
+
+    test('operator []', () {
+      final map = getMap();
+      expect(
+          map['key1']?.stringify(),
+          equals(
+              '{"key1":"strVal","key2":97,"key3":false,"key4":[1,2,3],"key5":null}'));
+      expect(map['key2']?.getBoolean(), isTrue);
+      expect(map['key3']?.getNumber(), equals(2022));
+      expect(map['key4']?.getString(), equals('strVal'));
+      expect(map['key5']?.valueType, equals(JsonValueType.null_));
+    });
+
+    test('operator []=', () {
+      final map = getMap();
+
+      // Replace an existing item.
+      expect(map.size, equals(5));
+      map['key4'] = JsonValue.createStringValue('strValNew');
+      expect(map.size, equals(5));
+      expect(map.lookup('key4')?.getString(), equals('strValNew'));
+
+      // Insert a new item.
+      map['key6'] = JsonValue.parse('{"hello": "world"}');
+      expect(map.size, equals(6));
+      expect(map.lookup('key6')?.stringify(), equals('{"hello":"world"}'));
+    });
   });
 }

--- a/packages/windows_devices/lib/src/enumeration/deviceinformationcollection.dart
+++ b/packages/windows_devices/lib/src/enumeration/deviceinformationcollection.dart
@@ -48,4 +48,11 @@ class DeviceInformationCollection extends IInspectable
 
   @override
   List<DeviceInformation> toList() => _iVectorView.toList();
+
+  @override
+  DeviceInformation operator [](int index) => _iVectorView[index];
+
+  @override
+  List<DeviceInformation> operator +(List<DeviceInformation> other) =>
+      toList() + other;
 }

--- a/packages/windows_devices/test/collections_test.dart
+++ b/packages/windows_devices/test/collections_test.dart
@@ -280,5 +280,38 @@ void main() {
       expect(iterator.current, equals(DeviceClass.imageScanner));
       expect(iterator.moveNext(), isFalse);
     });
+
+    test('operator []', () {
+      final vector = getVector()
+        ..append(DeviceClass.audioCapture)
+        ..append(DeviceClass.audioRender)
+        ..append(DeviceClass.imageScanner);
+      expect(vector[0], equals(DeviceClass.audioCapture));
+      expect(vector[1], equals(DeviceClass.audioRender));
+      expect(vector[2], equals(DeviceClass.imageScanner));
+    });
+
+    test('operator []=', () {
+      final vector = getVector()
+        ..append(DeviceClass.audioCapture)
+        ..append(DeviceClass.audioRender)
+        ..append(DeviceClass.imageScanner);
+      vector[1] = DeviceClass.location;
+      expect(vector.getAt(1), equals(DeviceClass.location));
+    });
+
+    test('operator +', () {
+      final vector = getVector()..append(DeviceClass.audioCapture);
+      final list = [DeviceClass.audioRender, DeviceClass.imageScanner];
+      final newList = vector + list;
+      expect(newList.length, equals(3));
+      expect(
+          newList,
+          orderedEquals([
+            DeviceClass.audioCapture,
+            DeviceClass.audioRender,
+            DeviceClass.imageScanner
+          ]));
+    });
   });
 }

--- a/packages/windows_foundation/lib/src/collections/imap.dart
+++ b/packages/windows_foundation/lib/src/collections/imap.dart
@@ -310,4 +310,13 @@ abstract class IMap<K, V> extends IInspectable
         keyValuePairs.map((kvp) => MapEntry(kvp.key, kvp.value)));
     return Map.unmodifiable(map);
   }
+
+  /// The value for the given [key], or `null` if [key] is not in the map.
+  V operator [](K key) => lookup(key);
+
+  /// Associates the [key] with the given [value].
+  ///
+  /// If the key was already in the map, its associated value is changed.
+  /// Otherwise the key/value pair is added to the map.
+  void operator []=(K key, V value) => insert(key, value);
 }

--- a/packages/windows_foundation/lib/src/collections/imapview.dart
+++ b/packages/windows_foundation/lib/src/collections/imapview.dart
@@ -237,4 +237,7 @@ abstract class IMapView<K, V> extends IInspectable
         keyValuePairs.map((kvp) => MapEntry(kvp.key, kvp.value)));
     return Map.unmodifiable(map);
   }
+
+  /// The value for the given [key], or `null` if [key] is not in the map.
+  V operator [](K key) => lookup(key);
 }

--- a/packages/windows_foundation/lib/src/collections/ipropertyset.dart
+++ b/packages/windows_foundation/lib/src/collections/ipropertyset.dart
@@ -80,4 +80,10 @@ class IPropertySet extends IInspectable
 
   @override
   Map<String, Object?> toMap() => _iMap.toMap();
+
+  @override
+  Object? operator [](String key) => _iMap[key];
+
+  @override
+  void operator []=(String key, Object? value) => _iMap[key] = value;
 }

--- a/packages/windows_foundation/lib/src/collections/ivector.dart
+++ b/packages/windows_foundation/lib/src/collections/ivector.dart
@@ -261,4 +261,34 @@ abstract class IVector<T> extends IInspectable implements IIterable<T> {
     getMany(0, size, list);
     return List.unmodifiable(list);
   }
+
+  /// The object at the given [index] in the list.
+  ///
+  /// The [index] must be a valid index of this list, which means that `index`
+  /// must be non-negative and less than [size].
+  T operator [](int index) {
+    if (index < 0 || index >= size) {
+      throw RangeError.range(index, 0, size - 1, 'index');
+    }
+    return getAt(index);
+  }
+
+  /// Sets the value at the given [index] in the list to [value].
+  ///
+  /// The [index] must be a valid index of this list, which means that `index`
+  /// must be non-negative and less than [size].
+  void operator []=(int index, T value) {
+    if (index < 0 || index >= size) {
+      throw RangeError.range(index, 0, size - 1, 'index');
+    }
+    setAt(index, value);
+  }
+
+  /// Returns the concatenation of this list and [other].
+  ///
+  /// Returns a new list containing the elements of this list followed by
+  /// the elements of [other].
+  ///
+  /// The default behavior is to return a normal growable list.
+  List<T> operator +(List<T> other) => toList() + other;
 }

--- a/packages/windows_foundation/lib/src/collections/ivectorview.dart
+++ b/packages/windows_foundation/lib/src/collections/ivectorview.dart
@@ -192,4 +192,24 @@ abstract class IVectorView<T> extends IInspectable implements IIterable<T> {
     getMany(0, size, list);
     return List.unmodifiable(list);
   }
+
+  /// The object at the given [index] in the list.
+  ///
+  /// The [index] must be a valid index of this list,
+  /// which means that `index` must be non-negative and
+  /// less than [size].
+  T operator [](int index) {
+    if (index < 0 || index >= size) {
+      throw RangeError.range(index, 0, size - 1, 'index');
+    }
+    return getAt(index);
+  }
+
+  /// Returns the concatenation of this list and [other].
+  ///
+  /// Returns a new list containing the elements of this list followed by
+  /// the elements of [other].
+  ///
+  /// The default behavior is to return a normal growable list.
+  List<T> operator +(List<T> other) => toList() + other;
 }

--- a/packages/windows_foundation/lib/src/collections/propertyset.dart
+++ b/packages/windows_foundation/lib/src/collections/propertyset.dart
@@ -79,4 +79,10 @@ class PropertySet extends IInspectable
 
   @override
   Map<String, Object?> toMap() => _iMap.toMap();
+
+  @override
+  Object? operator [](String key) => _iMap[key];
+
+  @override
+  void operator []=(String key, Object? value) => _iMap[key] = value;
 }

--- a/packages/windows_foundation/lib/src/collections/stringmap.dart
+++ b/packages/windows_foundation/lib/src/collections/stringmap.dart
@@ -67,6 +67,12 @@ class StringMap extends IInspectable
   @override
   Map<String, String> toMap() => _iMap.toMap();
 
+  @override
+  String operator [](String key) => _iMap[key];
+
+  @override
+  void operator []=(String key, String value) => _iMap[key] = value;
+
   late final _iObservableMap = IObservableMap<String, String>.fromPtr(
       toInterface('{1e036276-2f60-55f6-b7f3-f86079e6900b}'));
 

--- a/packages/windows_foundation/lib/src/collections/valueset.dart
+++ b/packages/windows_foundation/lib/src/collections/valueset.dart
@@ -82,4 +82,10 @@ class ValueSet extends IInspectable
 
   @override
   Map<String, Object?> toMap() => _iMap.toMap();
+
+  @override
+  Object? operator [](String key) => _iMap[key];
+
+  @override
+  void operator []=(String key, Object? value) => _iMap[key] = value;
 }

--- a/packages/windows_foundation/lib/src/iwwwformurldecoderruntimeclass.dart
+++ b/packages/windows_foundation/lib/src/iwwwformurldecoderruntimeclass.dart
@@ -92,4 +92,12 @@ class IWwwFormUrlDecoderRuntimeClass extends IInspectable
 
   @override
   List<IWwwFormUrlDecoderEntry> toList() => _iVectorView.toList();
+
+  @override
+  IWwwFormUrlDecoderEntry operator [](int index) => _iVectorView[index];
+
+  @override
+  List<IWwwFormUrlDecoderEntry> operator +(
+          List<IWwwFormUrlDecoderEntry> other) =>
+      toList() + other;
 }

--- a/packages/windows_foundation/lib/src/wwwformurldecoder.dart
+++ b/packages/windows_foundation/lib/src/wwwformurldecoder.dart
@@ -73,4 +73,12 @@ class WwwFormUrlDecoder extends IInspectable
 
   @override
   List<IWwwFormUrlDecoderEntry> toList() => _iVectorView.toList();
+
+  @override
+  IWwwFormUrlDecoderEntry operator [](int index) => _iVectorView[index];
+
+  @override
+  List<IWwwFormUrlDecoderEntry> operator +(
+          List<IWwwFormUrlDecoderEntry> other) =>
+      toList() + other;
 }

--- a/packages/windows_foundation/test/collections_test.dart
+++ b/packages/windows_foundation/test/collections_test.dart
@@ -263,6 +263,28 @@ void main() {
       expect(current.value, equals('icalendar'));
       expect(iterator.moveNext(), isFalse);
     });
+
+    test('operator []', () {
+      final map = getMap();
+      expect(map['key1'], isNull);
+      expect(map['key3'], isTrue);
+      expect(map['key5'], equals(0.5));
+    });
+
+    test('operator []=', () {
+      final map = getMap();
+
+      // Replace an existing item.
+      expect(map.size, equals(23));
+      map['key5'] = null;
+      expect(map.size, equals(23));
+      expect(map.lookup('key5'), isNull);
+
+      // Insert a new item.
+      map['key24'] = 24;
+      expect(map.size, equals(24));
+      expect(map.lookup('key24'), equals(24));
+    });
   });
 
   group('IMap<String, Object?> (ValueSet)', () {
@@ -495,6 +517,28 @@ void main() {
       expect(iterator.current.value, equals('icalendar'));
       expect(iterator.moveNext(), isFalse);
     });
+
+    test('operator []', () {
+      final map = getMap();
+      expect(map['key1'], isNull);
+      expect(map['key3'], isTrue);
+      expect(map['key5'], equals(0.5));
+    });
+
+    test('operator []=', () {
+      final map = getMap();
+
+      // Replace an existing item.
+      expect(map.size, equals(22));
+      map['key5'] = null;
+      expect(map.size, equals(22));
+      expect(map.lookup('key5'), isNull);
+
+      // Insert a new item.
+      map['key23'] = 23;
+      expect(map.size, equals(23));
+      expect(map.lookup('key23'), equals(23));
+    });
   });
 
   group('IMap<String, String> (StringMap)', () {
@@ -619,6 +663,28 @@ void main() {
       expect(current.value, equals('value1'));
       expect(iterator.moveNext(), isFalse);
     });
+
+    test('operator []', () {
+      final map = getMap();
+      expect(map['key1'], equals('value1'));
+      expect(map['key2'], isEmpty);
+      expect(map['key3'], equals('value3'));
+    });
+
+    test('operator []=', () {
+      final map = getMap();
+
+      // Replace an existing item.
+      expect(map.size, equals(3));
+      map['key3'] = 'newValue3';
+      expect(map.size, equals(3));
+      expect(map.lookup('key3'), equals('newValue3'));
+
+      // Insert a new item.
+      map['key4'] = 'value4';
+      expect(map.size, equals(4));
+      expect(map.lookup('key4'), equals('value4'));
+    });
   });
 
   group('IMapView<String, String> (StringMap)', () {
@@ -708,6 +774,13 @@ void main() {
       expect(current.key, equals('key1'));
       expect(current.value, equals('value1'));
       expect(iterator.moveNext(), isFalse);
+    });
+
+    test('operator []', () {
+      final map = getMapView();
+      expect(map['key1'], equals('value1'));
+      expect(map['key2'], isEmpty);
+      expect(map['key3'], equals('value3'));
     });
   });
 
@@ -989,6 +1062,38 @@ void main() {
       expect(iterator.current,
           equals(Uri.parse('https://flutter.dev/development')));
       expect(iterator.moveNext(), isFalse);
+    });
+
+    test('operator []', () {
+      final vector = getVector()
+        ..append(Uri.parse('https://dart.dev/overview'))
+        ..append(Uri.parse('https://dart.dev/docs'))
+        ..append(Uri.parse('https://flutter.dev/development'));
+      expect(vector[0], equals(Uri.parse('https://dart.dev/overview')));
+      expect(vector[1], equals(Uri.parse('https://dart.dev/docs')));
+      expect(vector[2], equals(Uri.parse('https://flutter.dev/development')));
+    });
+
+    test('operator []=', () {
+      final vector = getVector()
+        ..append(Uri.parse('https://dart.dev/overview'))
+        ..append(Uri.parse('https://dart.dev/docs'))
+        ..append(Uri.parse('https://flutter.dev/development'));
+      vector[1] = Uri.parse('https://dart.dev/tutorials');
+      expect(vector[1], equals(Uri.parse('https://dart.dev/tutorials')));
+    });
+
+    test('operator +', () {
+      final vector = getVector()..append(Uri.parse('https://dart.dev/docs'));
+      final list = [Uri.parse('https://dart.dev/tutorials')];
+      final newList = vector + list;
+      expect(newList.length, equals(2));
+      expect(
+          newList,
+          orderedEquals([
+            Uri.parse('https://dart.dev/docs'),
+            Uri.parse('https://dart.dev/tutorials')
+          ]));
     });
   });
 }

--- a/packages/windows_globalization/lib/src/collation/charactergroupings.dart
+++ b/packages/windows_globalization/lib/src/collation/charactergroupings.dart
@@ -69,4 +69,11 @@ class CharacterGroupings extends IInspectable
 
   @override
   List<CharacterGrouping> toList() => _iVectorView.toList();
+
+  @override
+  CharacterGrouping operator [](int index) => _iVectorView[index];
+
+  @override
+  List<CharacterGrouping> operator +(List<CharacterGrouping> other) =>
+      toList() + other;
 }

--- a/packages/windows_globalization/lib/src/collation/icharactergroupings.dart
+++ b/packages/windows_globalization/lib/src/collation/icharactergroupings.dart
@@ -84,4 +84,11 @@ class ICharacterGroupings extends IInspectable
 
   @override
   List<CharacterGrouping> toList() => _iVectorView.toList();
+
+  @override
+  CharacterGrouping operator [](int index) => _iVectorView[index];
+
+  @override
+  List<CharacterGrouping> operator +(List<CharacterGrouping> other) =>
+      toList() + other;
 }

--- a/packages/windows_globalization/test/collections_test.dart
+++ b/packages/windows_globalization/test/collections_test.dart
@@ -118,5 +118,20 @@ void main() {
         expect(iterator.moveNext(), i < list.length - 1);
       }
     });
+
+    test('operator []', () {
+      final vector = getVectorView();
+      // Should be something like en-US
+      expect(vector[0][2], equals('-'));
+    });
+
+    test('operator +', () {
+      final vector = getVectorView();
+      final list = ['tr-TR'];
+      final newList = vector + list;
+      expect(newList.length, equals(vector.size + 1));
+      expect(newList.first[2], equals('-'));
+      expect(newList.last, equals('tr-TR'));
+    });
   });
 }

--- a/packages/windows_graphics/test/collections_test.dart
+++ b/packages/windows_graphics/test/collections_test.dart
@@ -278,5 +278,32 @@ void main() {
       expect(iterator.current, equals(666));
       expect(iterator.moveNext(), isFalse);
     });
+
+    test('operator []', () {
+      final vector = getVector()
+        ..append(5)
+        ..append(259)
+        ..append(666);
+      expect(vector[0], equals(5));
+      expect(vector[1], equals(259));
+      expect(vector[2], equals(666));
+    });
+
+    test('operator []=', () {
+      final vector = getVector()
+        ..append(5)
+        ..append(259)
+        ..append(666);
+      vector[1] = 11811;
+      expect(vector.getAt(1), equals(11811));
+    });
+
+    test('operator +', () {
+      final vector = getVector()..append(259);
+      final list = [11811, 32367];
+      final newList = vector + list;
+      expect(newList.length, equals(3));
+      expect(newList, orderedEquals([259, 11811, 32367]));
+    });
   });
 }

--- a/packages/windows_media/lib/src/mediaproperties/mediapropertyset.dart
+++ b/packages/windows_media/lib/src/mediaproperties/mediapropertyset.dart
@@ -55,4 +55,10 @@ class MediaPropertySet extends IInspectable
 
   @override
   Map<Guid, Object?> toMap() => _iMap.toMap();
+
+  @override
+  Object? operator [](Guid key) => _iMap[key];
+
+  @override
+  void operator []=(Guid key, Object? value) => _iMap[key] = value;
 }

--- a/packages/windows_media/test/collections_test.dart
+++ b/packages/windows_media/test/collections_test.dart
@@ -278,5 +278,30 @@ void main() {
       expect(current.value, equals(259));
       expect(iterator.moveNext(), isFalse);
     });
+
+    test('operator []', () {
+      final map = getMap();
+      expect(map[Guid.parse(IID_IClosable)], isNull);
+      expect(map[Guid.parse(IID_IDispatch)], isTrue);
+      expect(map[Guid.parse(IID_IShellItemFilter)], equals('strVal'));
+    });
+
+    test('operator []=', () {
+      final map = getMap();
+
+      // Replace an existing item.
+      final guid1 = Guid.parse(IID_IShellItemFilter);
+      expect(map.size, equals(23));
+      map[guid1] = 'strValNew';
+      expect(map.size, equals(23));
+      expect(map.lookup(guid1), equals('strValNew'));
+
+      // Insert a new item.
+      final guid2 = Guid.parse(IID_IClassFactory);
+      expect(map.size, equals(23));
+      map[guid2] = 'iclassfactory';
+      expect(map.size, equals(24));
+      expect(map.lookup(guid2), equals('iclassfactory'));
+    });
   });
 }

--- a/packages/windows_networking/test/collections_test.dart
+++ b/packages/windows_networking/test/collections_test.dart
@@ -111,5 +111,19 @@ void main() {
         expect(iterator.moveNext(), i < list.length - 1);
       }
     });
+
+    test('operator []', () {
+      final vector = getVectorView();
+      expect(vector[0].displayName, isNotEmpty);
+    });
+
+    test('operator +', () {
+      final vector = getVectorView();
+      final list = [HostName.createHostName('test')];
+      final newList = vector + list;
+      expect(newList.length, equals(vector.size + 1));
+      expect(newList.first.displayName, isNotEmpty);
+      expect(newList.last.displayName, equals('test'));
+    });
   });
 }

--- a/packages/windows_storage/test/collections_test.dart
+++ b/packages/windows_storage/test/collections_test.dart
@@ -281,5 +281,38 @@ void main() {
       expect(current, equals('.png'));
       expect(iterator.moveNext(), isFalse);
     });
+
+    test('operator []', () {
+      final vector = getVector()
+        ..append('.jpg')
+        ..append('.jpeg')
+        ..append('.png');
+      expect(vector[0], equals('.jpg'));
+      expect(vector[1], equals('.jpeg'));
+      expect(vector[2], equals('.png'));
+    });
+
+    test('operator []=', () {
+      final vector = getVector()
+        ..append('.jpg')
+        ..append('.jpeg')
+        ..append('.png');
+      vector[1] = '.gif';
+      expect(vector.getAt(1), equals('.gif'));
+    });
+
+    test('operator +', () {
+      final vector = getVector()..append('.jpg');
+      final list = ['.jpeg', '.png'];
+      final newList = vector + list;
+      expect(newList.length, equals(3));
+      expect(
+          newList,
+          orderedEquals([
+            '.jpg',
+            '.jpeg',
+            '.png',
+          ]));
+    });
   });
 }

--- a/packages/winrtgen/lib/src/projections/method_forwarders.dart
+++ b/packages/winrtgen/lib/src/projections/method_forwarders.dart
@@ -188,9 +188,22 @@ class MethodForwardersProjection {
     }
 
     if (['IMap', 'IMapView'].contains(shortInterfaceName)) {
-      methods.add(mapPostamble());
+      methods.addAll([
+        mapFirstForwarder(),
+        mapToMapForwarder(),
+        mapSubscriptAccessOperatorForwarder(),
+        if (shortInterfaceName == 'IMap')
+          mapSubscriptAssignmentOperatorForwarder()
+      ]);
     } else if (['IVector', 'IVectorView'].contains(shortInterfaceName)) {
-      methods.add(vectorPostamble());
+      methods.addAll([
+        vectorFirstForwarder(),
+        vectorToListForwarder(),
+        vectorSubscriptAccessOperatorForwarder(),
+        if (shortInterfaceName == 'IVector')
+          vectorSubscriptAssignmentOperatorForwarder(),
+        vectorAddOperatorForwarder()
+      ]);
     }
 
     return methods;
@@ -223,6 +236,35 @@ class MethodForwardersProjection {
 ''';
   }
 
+  String mapFirstForwarder() => '''
+  @override
+  IIterator<IKeyValuePair<$typeArgs>> first() => $fieldIdentifier.first();
+''';
+
+  String mapToMapForwarder() => '''
+  @override
+  Map<$typeArgs> toMap() => $fieldIdentifier.toMap();
+''';
+
+  String mapSubscriptAccessOperatorForwarder() {
+    final keyType = typeArgs.split(', ')[0];
+    final valueType = typeArgs.split(', ')[1];
+    return '''
+  @override
+  $valueType operator []($keyType key) => $fieldIdentifier[key];
+  ''';
+  }
+
+  String mapSubscriptAssignmentOperatorForwarder() {
+    final keyType = typeArgs.split(', ')[0];
+    final valueType = typeArgs.split(', ')[1];
+    return '''
+  @override
+  void operator []=($keyType key, $valueType value) =>
+      $fieldIdentifier[key] = value;
+  ''';
+  }
+
   String vectorAppendForwarder() => '''
   @override
   void append(${stripQuestionMarkSuffix(typeArgs)} value) =>
@@ -247,23 +289,32 @@ class MethodForwardersProjection {
       $fieldIdentifier.setAt(index, value);
 ''';
 
-  /// Method forwarders for IIterable's `first()` and IMap/IMapView's `toMap()`.
-  String mapPostamble() => '''
-  @override
-  IIterator<IKeyValuePair<$typeArgs>> first() => $fieldIdentifier.first();
-
-  @override
-  Map<$typeArgs> toMap() => $fieldIdentifier.toMap();
-''';
-
-  /// Method forwarders for IIterable's `first()` and Vector/VectorView's
-  /// `toList()`.
-  String vectorPostamble() => '''
+  String vectorFirstForwarder() => '''
   @override
   IIterator<$typeArgs> first() => $fieldIdentifier.first();
+''';
 
+  String vectorToListForwarder() => '''
   @override
   List<$typeArgs> toList() => $fieldIdentifier.toList();
+''';
+
+  String vectorSubscriptAccessOperatorForwarder() => '''
+  @override
+  ${stripQuestionMarkSuffix(typeArgs)} operator [](int index) =>
+      $fieldIdentifier[index];
+''';
+
+  String vectorSubscriptAssignmentOperatorForwarder() => '''
+  @override
+  void operator []=(int index, ${stripQuestionMarkSuffix(typeArgs)} value) =>
+      $fieldIdentifier[index] = value;
+''';
+
+  String vectorAddOperatorForwarder() => '''
+  @override
+  List<$typeArgs> operator +(List<${stripQuestionMarkSuffix(typeArgs)}> other) =>
+      toList() + other;
 ''';
 
   @override


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

- Overloads `[]`, `[]=`, and `+` operators for `IVector`
- Overloads `[]` and `+` operators for `IVectorView`
- Overloads `[]` and `[]=` operators for `IMap`
- Overloads `[]` operator for `IMapView`

## Related Issue

None

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
