### PR TITLE
style(windows_security): use double quotes in `@Deprecated` annotations

### DIFF
--- a/packages/windows_security/lib/src/credentials/iwebaccountprovider.dart
+++ b/packages/windows_security/lib/src/credentials/iwebaccountprovider.dart
@@ -78,7 +78,7 @@ class IWebAccountProvider extends IInspectable {
   }
 
   @Deprecated(
-      'IconUri may be altered or unavailable for releases after Windows 8.2. Instead, use Icon.')
+      "IconUri may be altered or unavailable for releases after Windows 8.2. Instead, use Icon.")
   Uri? get iconUri {
     final retValuePtr = calloc<COMObject>();
 

--- a/packages/windows_security/lib/src/credentials/iwebaccountprovider2.dart
+++ b/packages/windows_security/lib/src/credentials/iwebaccountprovider2.dart
@@ -88,7 +88,7 @@ class IWebAccountProvider2 extends IInspectable implements IWebAccountProvider {
   String get displayName => _iWebAccountProvider.displayName;
 
   @Deprecated(
-      'IconUri may be altered or unavailable for releases after Windows 8.2. Instead, use Icon.')
+      "IconUri may be altered or unavailable for releases after Windows 8.2. Instead, use Icon.")
   @override
   Uri? get iconUri => _iWebAccountProvider.iconUri;
 }

--- a/packages/windows_security/lib/src/credentials/iwebaccountprovider3.dart
+++ b/packages/windows_security/lib/src/credentials/iwebaccountprovider3.dart
@@ -77,7 +77,7 @@ class IWebAccountProvider3 extends IInspectable
   String get displayName => _iWebAccountProvider.displayName;
 
   @Deprecated(
-      'IconUri may be altered or unavailable for releases after Windows 8.2. Instead, use Icon.')
+      "IconUri may be altered or unavailable for releases after Windows 8.2. Instead, use Icon.")
   @override
   Uri? get iconUri => _iWebAccountProvider.iconUri;
 }

--- a/packages/windows_security/lib/src/credentials/webaccountprovider.dart
+++ b/packages/windows_security/lib/src/credentials/webaccountprovider.dart
@@ -50,7 +50,7 @@ class WebAccountProvider extends IInspectable
   String get displayName => _iWebAccountProvider.displayName;
 
   @Deprecated(
-      'IconUri may be altered or unavailable for releases after Windows 8.2. Instead, use Icon.')
+      "IconUri may be altered or unavailable for releases after Windows 8.2. Instead, use Icon.")
   @override
   Uri? get iconUri => _iWebAccountProvider.iconUri;
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

Apparently, I forgot to re-run the `generate.cmd` in #191 after the PR that changes generated `@Deprecated` annotations to use double quotes landed.

## Related Issue

<!--- Link the relevant issue here -->

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
